### PR TITLE
[refactor] 준비 현황 뷰 디자인 명세 반영

### DIFF
--- a/KkuMulKum.xcodeproj/project.pbxproj
+++ b/KkuMulKum.xcodeproj/project.pbxproj
@@ -27,13 +27,13 @@
 		784824F72C6E1C9900FE07A0 /* AuthServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784824F62C6E1C9900FE07A0 /* AuthServiceProtocol.swift */; };
 		784824FC2C75BF7900FE07A0 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784824FB2C75BF7900FE07A0 /* MyPageViewModel.swift */; };
 		784824FE2C75F25900FE07A0 /* MyPageEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784824FD2C75F25900FE07A0 /* MyPageEditViewController.swift */; };
-		784825092C77623C00FE07A0 /* MypageTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825082C77623C00FE07A0 /* MypageTargetType.swift */; };
-		7848250B2C77627200FE07A0 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7848250A2C77627200FE07A0 /* UserService.swift */; };
-		784825112C77666500FE07A0 /* MyPageUserServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825102C77666500FE07A0 /* MyPageUserServiceType.swift */; };
 		784825012C77016400FE07A0 /* MyPageEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825002C77016400FE07A0 /* MyPageEditView.swift */; };
 		784825032C77016F00FE07A0 /* MyPageEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825022C77016F00FE07A0 /* MyPageEditViewModel.swift */; };
 		784825052C7716E900FE07A0 /* MyPageAskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825042C7716E900FE07A0 /* MyPageAskViewController.swift */; };
 		784825072C77215B00FE07A0 /* MyPageTermsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825062C77215B00FE07A0 /* MyPageTermsViewController.swift */; };
+		784825092C77623C00FE07A0 /* MypageTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825082C77623C00FE07A0 /* MypageTargetType.swift */; };
+		7848250B2C77627200FE07A0 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7848250A2C77627200FE07A0 /* UserService.swift */; };
+		784825112C77666500FE07A0 /* MyPageUserServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784825102C77666500FE07A0 /* MyPageUserServiceType.swift */; };
 		784E4D942C3B1C7F00BC943C /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 784E4D932C3B1C7F00BC943C /* KakaoSDK */; };
 		784E4D962C3B1C7F00BC943C /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 784E4D952C3B1C7F00BC943C /* KakaoSDKAuth */; };
 		784E4D992C3B95A900BC943C /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 784E4D982C3B95A900BC943C /* KeychainAccess */; };
@@ -267,13 +267,13 @@
 		784824F62C6E1C9900FE07A0 /* AuthServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthServiceProtocol.swift; sourceTree = "<group>"; };
 		784824FB2C75BF7900FE07A0 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		784824FD2C75F25900FE07A0 /* MyPageEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageEditViewController.swift; sourceTree = "<group>"; };
-		784825082C77623C00FE07A0 /* MypageTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageTargetType.swift; sourceTree = "<group>"; };
-		7848250A2C77627200FE07A0 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
-		784825102C77666500FE07A0 /* MyPageUserServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageUserServiceType.swift; sourceTree = "<group>"; };
 		784825002C77016400FE07A0 /* MyPageEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageEditView.swift; sourceTree = "<group>"; };
 		784825022C77016F00FE07A0 /* MyPageEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageEditViewModel.swift; sourceTree = "<group>"; };
 		784825042C7716E900FE07A0 /* MyPageAskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAskViewController.swift; sourceTree = "<group>"; };
 		784825062C77215B00FE07A0 /* MyPageTermsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTermsViewController.swift; sourceTree = "<group>"; };
+		784825082C77623C00FE07A0 /* MypageTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageTargetType.swift; sourceTree = "<group>"; };
+		7848250A2C77627200FE07A0 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		784825102C77666500FE07A0 /* MyPageUserServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageUserServiceType.swift; sourceTree = "<group>"; };
 		789196332C486F6B00FF8CDF /* KeychainAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessible.swift; sourceTree = "<group>"; };
 		789196352C492F8600FF8CDF /* AuthTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTargetType.swift; sourceTree = "<group>"; };
 		789196372C49697B00FF8CDF /* AuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthError.swift; sourceTree = "<group>"; };
@@ -776,6 +776,7 @@
 			children = (
 				DD1FD02E2C5CCB2E00D0A72C /* ViewController */,
 				DD1FD0312C5CCEC300D0A72C /* View */,
+				DD3466492C7AF61A00E62284 /* Cell */,
 			);
 			path = ReadyStatus;
 			sourceTree = "<group>";
@@ -824,6 +825,14 @@
 				DD931B752C3DC16100526452 /* PromiseInfoView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		DD3466492C7AF61A00E62284 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				DD8626572C4606A300E4F980 /* OurReadyStatusCollectionViewCell.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		DD3976692C41769900E2A4C4 /* ViewModel */ = {
@@ -1202,7 +1211,6 @@
 			isa = PBXGroup;
 			children = (
 				DD41BF002C41DE4F0095A068 /* TardyCollectionViewCell.swift */,
-				DD8626572C4606A300E4F980 /* OurReadyStatusCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";

--- a/KkuMulKum/Source/Promise/ReadyStatus/Cell/OurReadyStatusCollectionViewCell.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/Cell/OurReadyStatusCollectionViewCell.swift
@@ -11,7 +11,6 @@ class OurReadyStatusCollectionViewCell: BaseCollectionViewCell {
     var profileImageView: UIImageView = UIImageView(image: .imgProfile).then {
         $0.contentMode = .scaleAspectFill
         $0.layer.cornerRadius = Screen.height(44) / 2
-        $0.clipsToBounds = true
     }
     
     let nameLabel: UILabel = UILabel().then {
@@ -27,8 +26,8 @@ class OurReadyStatusCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func setupView() {
-        backgroundColor = .white
-        layer.cornerRadius = 8
+        backgroundColor = .gray0
+        layer.cornerRadius = Screen.height(8)
         clipsToBounds = true
         
         addSubviews(
@@ -48,7 +47,7 @@ class OurReadyStatusCollectionViewCell: BaseCollectionViewCell {
         
         nameLabel.snp.makeConstraints {
             $0.centerY.equalTo(profileImageView)
-            $0.leading.equalTo(profileImageView.snp.trailing).offset(13)
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(12)
         }
         
         readyStatusButton.snp.makeConstraints {

--- a/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyStatusView.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyStatusView.swift
@@ -69,11 +69,16 @@ class ReadyStatusView: BaseView {
     }
     
     private let ourReadyStatusLabel: UILabel = UILabel().then {
-        $0.setText(
-            "우리들의 준비 현황",
-            style: .body01,
-            color: .gray8
-        )
+        $0.setText("우리들의 준비 현황", style: .body01, color: .gray8)
+    }
+    
+    private let ourReadyStatusBackView: UIView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = Screen.height(18)
+    }
+    
+    private let bottomBackgroundView: UIView = UIView().then {
+        $0.backgroundColor = .white
     }
     
     private var collectionViewHeightConstraint: Constraint?
@@ -91,18 +96,19 @@ class ReadyStatusView: BaseView {
             enterReadyButtonView,
             readyPlanInfoView,
             myReadyStatusTitleLabel,
-            readyBaseView,
-            ourReadyStatusLabel
+            readyBaseView
         )
         
         contentView.addSubviews(
             baseStackView,
+            ourReadyStatusBackView,
+            ourReadyStatusLabel,
             ourReadyStatusCollectionView
         )
         
         scrollView.addSubview(contentView)
         
-        addSubviews(scrollView)
+        addSubviews(scrollView, bottomBackgroundView)
         
     }
     
@@ -121,14 +127,36 @@ class ReadyStatusView: BaseView {
             $0.leading.trailing.equalToSuperview().inset(20)
         }
         
+        ourReadyStatusBackView.snp.makeConstraints {
+            $0.top.equalTo(baseStackView.snp.bottom).offset(24)
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        ourReadyStatusLabel.snp.makeConstraints {
+            $0.top.equalTo(readyBaseView.snp.bottom).offset(50)
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
         ourReadyStatusCollectionView.snp.makeConstraints {
-            $0.top.equalTo(baseStackView.snp.bottom).offset(22)
+            $0.top.equalTo(ourReadyStatusLabel.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(20)
             self.collectionViewHeightConstraint = $0.height.equalTo(0).constraint
         }
         
         contentView.snp.makeConstraints {
             $0.bottom.equalTo(ourReadyStatusCollectionView.snp.bottom).offset(20)
+        }
+        
+        ourReadyStatusBackView.snp.makeConstraints {
+            $0.top.equalTo(readyBaseView.snp.bottom).offset(24)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+        
+        bottomBackgroundView.snp.makeConstraints {
+            $0.top.equalTo(contentView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(Screen.height(600))
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #316

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 디자인 명세 반영해서 준비 현황 뷰 수정했습니다.

|    구현 내용    |   IPhone 15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/bbf46423-b48b-4eb8-8229-b0d8cf31ae30" width ="250"> |
