### PR TITLE
[feat] 준비 정보 수정 플로우 추가

### DIFF
--- a/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyPlanInfoView.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyPlanInfoView.swift
@@ -26,11 +26,9 @@ class ReadyPlanInfoView: BaseView {
     }
     
     private let editButton: UIButton = UIButton().then {
-        $0.setTitle("수정", for: .normal)
-        $0.setTitleColor(.gray6, for: .normal)
-        $0.titleLabel?.font = .pretendard(.caption01)
+        $0.setTitle("수정", style: .caption01, color: .gray6)
         $0.backgroundColor = .gray0
-        $0.layer.cornerRadius = 50
+        $0.layer.cornerRadius = Screen.height(28) / 2
         $0.clipsToBounds = true
     }
     
@@ -68,6 +66,7 @@ class ReadyPlanInfoView: BaseView {
         editButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(22)
             $0.bottom.equalToSuperview().inset(18)
+            $0.width.equalTo(Screen.width(60))
             $0.height.equalTo(Screen.height(28))
         }
     }

--- a/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyPlanInfoView.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyPlanInfoView.swift
@@ -25,7 +25,7 @@ class ReadyPlanInfoView: BaseView {
         $0.setText("이동 소요 시간: 1시간 30분", style: .label02, color: .gray8)
     }
     
-    private let editButton: UIButton = UIButton().then {
+    let editButton: UIButton = UIButton().then {
         $0.setTitle("수정", style: .caption01, color: .gray6)
         $0.backgroundColor = .gray0
         $0.layer.cornerRadius = Screen.height(28) / 2

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -447,14 +447,19 @@ extension ReadyStatusViewController {
         guard let _ = viewModel.promiseInfo.value?.promiseName else { return }
         guard let readyStatusInfo = viewModel.myReadyStatus.value else { return }
         
-        let setReadyInfoViewController = SetReadyInfoViewController(
-            viewModel: SetReadyInfoViewModel(
-                promiseID: viewModel.promiseID,
-                promiseTime: readyStatusInfo.promiseTime,
-                promiseName: viewModel.promiseInfo.value?.promiseName ?? "",
-                service: PromiseService()
-            )
+        let setReadyInfoViewModel = SetReadyInfoViewModel(
+            promiseID: viewModel.promiseID,
+            promiseTime: readyStatusInfo.promiseTime,
+            promiseName: viewModel.promiseInfo.value?.promiseName ?? "",
+            service: PromiseService()
         )
+        
+        setReadyInfoViewModel.storedReadyHour = (readyStatusInfo.preparationTime ?? 0) / 60
+        setReadyInfoViewModel.storedReadyMinute = (readyStatusInfo.preparationTime ?? 0) % 60
+        setReadyInfoViewModel.storedMoveHour = (readyStatusInfo.travelTime ?? 0) / 60
+        setReadyInfoViewModel.storedMoveMinute = (readyStatusInfo.travelTime ?? 0) % 60
+        
+        let setReadyInfoViewController = SetReadyInfoViewController(viewModel: setReadyInfoViewModel)
         
         navigationController?.pushViewController(
             setReadyInfoViewController,

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -77,6 +77,11 @@ class ReadyStatusViewController: BaseViewController {
             action: #selector(arrivalButtonDidTap),
             for: .touchUpInside
         )
+        rootView.readyPlanInfoView.editButton.addTarget(
+            self,
+            action: #selector(editReadyButtonDidTap),
+            for: .touchUpInside
+        )
         rootView.enterReadyButtonView.addGestureRecognizer(
             UITapGestureRecognizer(
                 target: self,
@@ -435,6 +440,26 @@ extension ReadyStatusViewController {
     func arrivalButtonDidTap() {
         viewModel.myReadyProgressStatus.value = .done
         rootView.myReadyStatusProgressView.arrivalButton.isEnabled = false
+    }
+    
+    @objc
+    func editReadyButtonDidTap() {
+        guard let _ = viewModel.promiseInfo.value?.promiseName else { return }
+        guard let readyStatusInfo = viewModel.myReadyStatus.value else { return }
+        
+        let setReadyInfoViewController = SetReadyInfoViewController(
+            viewModel: SetReadyInfoViewModel(
+                promiseID: viewModel.promiseID,
+                promiseTime: readyStatusInfo.promiseTime,
+                promiseName: viewModel.promiseInfo.value?.promiseName ?? "",
+                service: PromiseService()
+            )
+        )
+        
+        navigationController?.pushViewController(
+            setReadyInfoViewController,
+            animated: true
+        )
     }
     
     @objc

--- a/KkuMulKum/Source/SetReadyInfo/ViewController/SetReadyInfoViewController.swift
+++ b/KkuMulKum/Source/SetReadyInfo/ViewController/SetReadyInfoViewController.swift
@@ -30,12 +30,6 @@ final class SetReadyInfoViewController: BaseViewController {
     
     // MARK: - LifeCycle
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        navigationController?.isNavigationBarHidden = false
-    }
-    
     override func loadView() {
         self.view = rootView
     }
@@ -47,8 +41,15 @@ final class SetReadyInfoViewController: BaseViewController {
         setupNavigationBarBackButton()
         setupNavigationBarTitle(with: "준비 정보 입력하기")
         
-        bindViewModel()
+        setupBinding()
         setupTapGesture()
+        setupTextField()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        navigationController?.isNavigationBarHidden = false
     }
     
     override func setupDelegate() {
@@ -121,10 +122,13 @@ extension SetReadyInfoViewController: UITextFieldDelegate {
     
     func textFieldDidEndEditing(_ textField: UITextField) {
         textField.layer.borderColor = UIColor.gray3.cgColor
-        viewModel.updateTime(
-            textField: textField.accessibilityIdentifier ?? "",
-            time: textField.text ?? ""
-        )
+        
+        if let text = textField.text, !text.isEmpty {
+            viewModel.updateTime(
+                textField: textField.accessibilityIdentifier ?? "",
+                time: textField.text ?? ""
+            )
+        }
     }
     
     func textField(
@@ -142,6 +146,20 @@ extension SetReadyInfoViewController: UITextFieldDelegate {
 // MARK: - Function
 
 private extension SetReadyInfoViewController {
+    func setupTextField() {
+        /// 저장된 준비 시간이 0이 아니면 텍스트 필드에 설정
+        if viewModel.storedReadyHour != 0 || viewModel.storedReadyMinute != 0 {
+            rootView.readyHourTextField.text = String(viewModel.storedReadyHour)
+            rootView.readyMinuteTextField.text = String(viewModel.storedReadyMinute)
+        }
+        
+        /// 저장된 이동 시간이 0이 아니면 텍스트 필드에 설정
+        if viewModel.storedMoveHour != 0 || viewModel.storedMoveMinute != 0 {
+            rootView.moveHourTextField.text = String(viewModel.storedMoveHour)
+            rootView.moveMinuteTextField.text = String(viewModel.storedMoveMinute)
+        }
+    }
+    
     func setTextFieldDelegate() {
         let textFields: [(UITextField, String)] = [
             (rootView.readyHourTextField, "readyHour"),
@@ -164,7 +182,7 @@ private extension SetReadyInfoViewController {
     
     // MARK: - Data Bind
     
-    func bindViewModel() {
+    func setupBinding() {
         viewModel.readyHour.bind { [weak self] readyHour in
             self?.rootView.readyHourTextField.text = readyHour
         }

--- a/KkuMulKum/Source/SetReadyInfo/ViewController/SetReadyInfoViewController.swift
+++ b/KkuMulKum/Source/SetReadyInfo/ViewController/SetReadyInfoViewController.swift
@@ -86,6 +86,8 @@ final class SetReadyInfoViewController: BaseViewController {
     
     @objc
     private func textFieldDidChange(_ textField: UITextField) {
+        let text = textField.text ?? ""
+        viewModel.updateTime(textField: textField.accessibilityIdentifier ?? "", time: text)
         viewModel.checkValid(
             readyHourText: rootView.readyHourTextField.text ?? "",
             readyMinuteText: rootView.readyMinuteTextField.text ?? "",

--- a/KkuMulKum/Source/SetReadyInfo/ViewController/SetReadyInfoViewController.swift
+++ b/KkuMulKum/Source/SetReadyInfo/ViewController/SetReadyInfoViewController.swift
@@ -160,6 +160,13 @@ private extension SetReadyInfoViewController {
             rootView.moveHourTextField.text = String(viewModel.storedMoveHour)
             rootView.moveMinuteTextField.text = String(viewModel.storedMoveMinute)
         }
+        
+        viewModel.checkValid(
+            readyHourText: rootView.readyHourTextField.text ?? "",
+            readyMinuteText: rootView.readyMinuteTextField.text ?? "",
+            moveHourText: rootView.moveHourTextField.text ?? "",
+            moveMinuteText: rootView.moveMinuteTextField.text ?? ""
+        )
     }
     
     func setTextFieldDelegate() {

--- a/KkuMulKum/Source/SetReadyInfo/ViewModel/SetReadyInfoViewModel.swift
+++ b/KkuMulKum/Source/SetReadyInfo/ViewModel/SetReadyInfoViewModel.swift
@@ -15,12 +15,20 @@ final class SetReadyInfoViewModel {
     
     let isValid = ObservablePattern<Bool>(false)
     let errMessage = ObservablePattern<String>("")
-    
-    let readyHour = ObservablePattern<String>("")
-    let readyMinute = ObservablePattern<String>("")
-    let moveHour = ObservablePattern<String>("")
-    let moveMinute = ObservablePattern<String>("")
     let isSucceedToSave = ObservablePattern<Bool>(false)
+    
+    var readyHour = ObservablePattern<String>("")
+    var readyMinute = ObservablePattern<String>("")
+    var moveHour = ObservablePattern<String>("")
+    var moveMinute = ObservablePattern<String>("")
+    
+    var preparationTime = ObservablePattern<Int>(0)
+    var travelTime = ObservablePattern<Int>(0)
+    
+    var storedReadyHour: Int = 0
+    var storedReadyMinute: Int = 0
+    var storedMoveHour: Int = 0
+    var storedMoveMinute: Int = 0
     
     var readyTime: Int = 0
     var moveTime: Int = 0
@@ -52,10 +60,10 @@ final class SetReadyInfoViewModel {
     }
     
     private func calculateTimes() {
-        let readyHours = Int(readyHour.value) ?? 0
-        let readyMinutes = Int(readyMinute.value) ?? 0
-        let moveHours = Int(moveHour.value) ?? 0
-        let moveMinutes = Int(moveMinute.value) ?? 0
+        let readyHours = Int(readyHour.value) ?? storedReadyHour
+        let readyMinutes = Int(readyMinute.value) ?? storedReadyMinute
+        let moveHours = Int(moveHour.value) ?? storedMoveHour
+        let moveMinutes = Int(moveMinute.value) ?? storedMoveMinute
         
         readyTime = readyHours * 60 + readyMinutes
         moveTime = moveHours * 60 + moveMinutes


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #358 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 약속 상세의 준비 현황 페이지에서 수정 버튼의 레이아웃 오류를 해결했습니다.
- 준비 정보 수정 플로우를 추가했습니다. 
- 텍스트필드의 상태변화(filled/type/press/default), 텍스트필드 입력에 따른 완료 버튼 활성화, 준비현황에서의 수정사항 반영을 고려하여 작업했습니다.

**예상한 경우의 수에 따라 작업한 세부 사항은 다음과 같습니다.**
- 수정 화면에서 이전에 입력한 값이 입력되어 있습니다.
- 준비시간 혹은 이동시간을 0으로 입력한 경우, 즉 준비시간 혹은 이동시간이 0분인 경우(준비시간/준비분이 0인 경우 혹은 이동시간/이동분이 0) 다시 수정 화면에 진입했을 때 해당 텍스트필드는 00을 플레이스 홀더로 가진 초기 디폴트 상태로 돌아갑니다.
- 0시간 20분, 1시간 0분과 같이 준비시간 혹은 이동시간이 0분이 아닌 경우에는 일부 텍스트필드 값이 0이더라도 위 사항(플레이스 홀더)이 반영되지 않습니다.
- 텍스트필드를 수정하지 않아도 완료 버튼이 활성화됩니다. (아래 동작 화면에는 반영되어 있지 않습니다. 마지막 커밋을 참고해주세요!)
- 기존 기능에서의 텍스트필드 상태는 수정 단계에서도 유효합니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 네 텍스트 필드를 모두 수정하는 경우 | <img src = "https://github.com/user-attachments/assets/9ce508ae-ad5a-45a7-9fe5-0790e4465f7a" width ="250"> |
| 일부 텍스트 필드를 수정하는 경우 | <img src = "https://github.com/user-attachments/assets/a3095ff0-634d-4510-a7f8-923c9d5fde9b" width ="250"> |
| 네 텍스트 필드를 모두 0으로 수정하는 경우 | <img src = "https://github.com/user-attachments/assets/2d130c56-da91-4616-93bd-95e80404d604" width ="250"> |
| 일부 텍스트 필드를 0으로 수정하는 경우(준비시간 혹은 이동시간이 0이 되는 경우) | <img src = "https://github.com/user-attachments/assets/ec9531ce-48d5-458c-9b83-430ee81d356b" width ="250"> |
| 일부 텍스트 필드를 0으로 수정하는 경우 | <img src = "https://github.com/user-attachments/assets/50eec679-ce26-4d7e-9ac0-cccfbd50cbbc" width ="250"> |


**처음 입력하는 경우의 동작 화면입니다. 수정된 코드가 기존의 기능 구현에 영향을 미치지 않는 것을 확인했습니다.**
- 회색 텍스트 00을 플레이스 홀더로 가지고 있습니다.
- 텍스트필드의 값이 모두 입력되었을 때 완료 버튼이 활성화됩니다.
- 잘못된 값을 입력할 시, 토스트 메시지와 함께 텍스트필드의 값이 수정됩니다. (따라서, 특정 값을 입력했다가 지웠을 경우 완료 버튼이 활성화되지 않습니다.)

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/b63e8480-d825-4d99-86a8-a4291ea98b3d" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
**텍스트필드의 상태변화(filled/type/press/default), 텍스트필드 입력에 따른 완료 버튼 활성화, 준비현황에서의 수정사항 반영을 중심적으로 확인해주세요!** 경우의 수가 끝 없이 나오네요ㅜㅜ 혹시 제가 고려하지 못한 경우가 있다면 말씀해주시길 .. 😿 