### PR TITLE
[fix] 네비게이션바 경계선 로직 수정

### DIFF
--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -61,7 +61,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let mainTabBarController = MainTabBarController()
         let navigationController = UINavigationController(
             rootViewController: mainTabBarController,
-            isBorderNeeded: true
+            isBorderNeeded: false
         )
         navigationController.isNavigationBarHidden = true
         

--- a/KkuMulKum/Resource/Base/BaseViewController.swift
+++ b/KkuMulKum/Resource/Base/BaseViewController.swift
@@ -44,12 +44,9 @@ extension BaseViewController {
             .font: UIFont.pretendard(.body03)
         ]
         
-        isBorderHidden ? navigationController?.hideBorder() : navigationController?.showBorder()
-        
-        let barAppearance = UINavigationBarAppearance()
-        barAppearance.backgroundColor = .white
-        navigationItem.standardAppearance = barAppearance
-        navigationItem.scrollEdgeAppearance = barAppearance
+        if !isBorderHidden {
+            addBorder()
+        }
     }
     
     /// 네비게이션 바 BackButton 구성
@@ -83,5 +80,28 @@ private extension BaseViewController {
     @objc
     func backButtonDidTap() {
         navigationController?.popViewController(animated: true)
+    }
+    
+    func addBorder() {
+        let identifier = "border"
+        guard view.subviews.first(where: { $0.accessibilityIdentifier == identifier }) == nil else { return }
+        
+        let safeArea = view.safeAreaLayoutGuide
+        let border = UIView(backgroundColor: .gray2).then {
+            $0.accessibilityIdentifier = identifier
+        }
+        
+        view.addSubview(border)
+        
+        border.snp.makeConstraints {
+            $0.top.equalTo(safeArea)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+        view.bringSubviewToFront(border)
+        
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
     }
 }

--- a/KkuMulKum/Resource/Base/BaseViewController.swift
+++ b/KkuMulKum/Resource/Base/BaseViewController.swift
@@ -67,11 +67,17 @@ extension BaseViewController {
     }
 }
 
+
+// MARK: - UIGestureRecognizerDelegate
+
 extension BaseViewController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return navigationController?.viewControllers.count ?? 0 > 1
     }
 }
+
+
+// MARK: - Private Method
 
 private extension BaseViewController {
     @objc

--- a/KkuMulKum/Resource/Extension/UINavigationController+.swift
+++ b/KkuMulKum/Resource/Extension/UINavigationController+.swift
@@ -11,45 +11,11 @@ extension UINavigationController {
     convenience init(rootViewController: UIViewController, isBorderNeeded: Bool) {
         self.init(rootViewController: rootViewController)
         
-        if isBorderNeeded {
-            addBorder()
-        }
-    }
-    
-    func showBorder() {
-        let border = findBottomBorder()
-        border?.isHidden = false
-    }
-    
-    func hideBorder() {
-        let border = findBottomBorder()
-        border?.isHidden = true
-    }
-}
-
-private extension UINavigationController {
-    enum Constants {
-        static let bottomBorderName = "BottomBorder"
-        static let bottomBorderWidth: CGFloat = Screen.height(1)
-    }
-    
-    func addBorder() {
-        guard findBottomBorder() == nil else { return }
+        let barAppearance = UINavigationBarAppearance()
+        barAppearance.backgroundColor = .white
+        barAppearance.shadowColor = isBorderNeeded ? .gray2 : nil
         
-        let border = CALayer()
-        border.name = Constants.bottomBorderName
-        border.backgroundColor = UIColor.gray2.cgColor
-        border.frame = CGRect(
-            x: 0,
-            y: navigationBar.frame.height - Constants.bottomBorderWidth,
-            width: navigationBar.frame.width,
-            height: Constants.bottomBorderWidth
-        )
-        
-        navigationBar.layer.addSublayer(border)
-    }
-    
-    func findBottomBorder() -> CALayer? {
-        return navigationBar.layer.sublayers?.first(where: { $0.name == Constants.bottomBorderName })
+        navigationBar.standardAppearance = barAppearance
+        navigationBar.scrollEdgeAppearance = barAppearance
     }
 }

--- a/KkuMulKum/Source/AddPromise/ViewController/AddPromiseCompleteViewController.swift
+++ b/KkuMulKum/Source/AddPromise/ViewController/AddPromiseCompleteViewController.swift
@@ -38,7 +38,7 @@ final class AddPromiseCompleteViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupNavigationBarTitle(with: "내 모임 추가하기")
+        setupNavigationBarTitle(with: "내 모임 추가하기", isBorderHidden: true)
         navigationItem.hidesBackButton = true
     }
     
@@ -63,7 +63,6 @@ final class AddPromiseCompleteViewController: BaseViewController {
                     animated: false
                 )
                 rootViewController.navigationController?.pushViewController(
-                    
                     PromiseViewController(
                         viewModel: PromiseViewModel(
                             promiseID: owner.promiseID,

--- a/KkuMulKum/Source/AddPromise/ViewController/AddPromiseViewController.swift
+++ b/KkuMulKum/Source/AddPromise/ViewController/AddPromiseViewController.swift
@@ -42,7 +42,7 @@ final class AddPromiseViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupNavigationBarTitle(with: "약속 추가하기")
+        setupNavigationBarTitle(with: "약속 추가하기", isBorderHidden: true)
         setupNavigationBarBackButton()
         
         bindViewModel()

--- a/KkuMulKum/Source/AddPromise/ViewController/SelectMemberViewController.swift
+++ b/KkuMulKum/Source/AddPromise/ViewController/SelectMemberViewController.swift
@@ -41,7 +41,7 @@ final class SelectMemberViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupNavigationBarTitle(with: "약속 추가하기")
+        setupNavigationBarTitle(with: "약속 추가하기", isBorderHidden: true)
         setupNavigationBarBackButton()
         
         bindViewModel()

--- a/KkuMulKum/Source/AddPromise/ViewController/SelectPenaltyViewController.swift
+++ b/KkuMulKum/Source/AddPromise/ViewController/SelectPenaltyViewController.swift
@@ -40,7 +40,7 @@ final class SelectPenaltyViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupNavigationBarTitle(with: "약속 추가하기")
+        setupNavigationBarTitle(with: "약속 추가하기", isBorderHidden: true)
         setupNavigationBarBackButton()
         
         bindViewModel()

--- a/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
@@ -96,7 +96,7 @@ private extension MeetingInfoViewController {
         output.info
             .drive(with: self) { owner, meetingInfo in
                 guard let info = meetingInfo else { return }
-                owner.title = info.name
+                owner.setupNavigationBarTitle(with: info.name)
                 owner.rootView.configureInfo(
                     createdAt: info.createdAt,
                     metCount: info.metCount

--- a/KkuMulKum/Source/Onboarding/Login/ViewController/LoginViewController.swift
+++ b/KkuMulKum/Source/Onboarding/Login/ViewController/LoginViewController.swift
@@ -84,7 +84,7 @@ class LoginViewController: BaseViewController {
             let mainTabBarController = MainTabBarController()
             let navigationController = UINavigationController(
                 rootViewController: mainTabBarController,
-                isBorderNeeded: true
+                isBorderNeeded: false
             )
             navigationController.isNavigationBarHidden = true
             navigationController.modalPresentationStyle = .fullScreen
@@ -102,7 +102,7 @@ class LoginViewController: BaseViewController {
             } else {
                 let navigationController = UINavigationController(
                     rootViewController: nicknameViewController,
-                    isBorderNeeded: true
+                    isBorderNeeded: false
                 )
                 navigationController.modalPresentationStyle = .fullScreen
                 navigationController.modalTransitionStyle = .crossDissolve

--- a/KkuMulKum/Source/Onboarding/Welcome/ViewController/WelcomeViewController.swift
+++ b/KkuMulKum/Source/Onboarding/Welcome/ViewController/WelcomeViewController.swift
@@ -54,7 +54,7 @@ class WelcomeViewController: BaseViewController {
         
         let navigationController = UINavigationController(
             rootViewController: mainTabBarController,
-            isBorderNeeded: true
+            isBorderNeeded: false
         )
         
         navigationController.isNavigationBarHidden = true

--- a/KkuMulKum/Source/Promise/PagePromise/ViewController/PromiseViewController.swift
+++ b/KkuMulKum/Source/Promise/PagePromise/ViewController/PromiseViewController.swift
@@ -149,7 +149,7 @@ class PromiseViewController: BaseViewController {
 private extension PromiseViewController {
     func setupBindings() {
         viewModel.promiseInfo.bindOnMain(with: self) { owner, info in
-            owner.setupNavigationBarTitle(with: info?.promiseName ?? "", isBorderHidden: false)
+            owner.setupNavigationBarTitle(with: info?.promiseName ?? "", isBorderHidden: true)
             
             owner.promiseInfoViewController.rootView.editButton.isHidden = !(info?.isParticipant ?? false)
             owner.setupPromiseEditButton(isHidden: !(info?.isParticipant ?? false))


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #368 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 네비게이션바 경계선 로직을 수정하였습니다.

|    구현 내용    |   IPhone 11 pro max   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/08119043-9112-4b3e-8441-2527e05b2605" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 독립적인 경계선
- 하나의 NavigationController에 접근하여, 경계선을 토글형식으로 관리하는 것이 스택으로 관리되어지는 특성상 앞뒤 화면에 매우 의존적이라는 생각이 들게 되었습니다.
- 따라서, 아예 필요한 화면에서만 `view`에 경계선을 추가하여 독립적인 화면으로 존재하도록 하였습니다.

<details>
<summary>BaseViewController.swift</summary>

```swift
func addBorder() {
    let identifier = "border"
    guard view.subviews.first(where: { $0.accessibilityIdentifier == identifier }) == nil else { return }
    
    let safeArea = view.safeAreaLayoutGuide
    let border = UIView(backgroundColor: .gray2).then {
        $0.accessibilityIdentifier = identifier
    }
    
    view.addSubview(border)
    
    border.snp.makeConstraints {
        $0.top.equalTo(safeArea)
        $0.horizontalEdges.equalToSuperview()
        $0.height.equalTo(1)
    }
    
    view.bringSubviewToFront(border)
    
    view.setNeedsLayout()
    view.layoutIfNeeded()
}
```
</details>

### 그렇다면 네비게이션 컨트롤러는?
- `shadowImage` 혹은 `shadowColor`가 `nil`이 아니면 기본적으로 보여지는 시스템적인 경계선이 있었습니다.
- 기존에 만들어 두었던 편의생성자에서 일부 로직을 수행하여, 생성될 때 필요하면 경계선이 나타나도록 하였습니다.
- 현재의 경우는 아예 뷰컨트롤러의 `view`에 경계선을 추가하기 때문에 필요없게끔 코드를 수정하였습니다.

<details>
<summary>UINavigationController+.swift</summary>

```swift
extension UINavigationController {
    convenience init(rootViewController: UIViewController, isBorderNeeded: Bool) {
        self.init(rootViewController: rootViewController)
        
        let barAppearance = UINavigationBarAppearance()
        barAppearance.backgroundColor = .white
        barAppearance.shadowColor = isBorderNeeded ? .gray2 : nil
        
        navigationBar.standardAppearance = barAppearance
        navigationBar.scrollEdgeAppearance = barAppearance
    }
}
```
</details>

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 당장 생각났던 곳인 [약속 상세, 약속 추가 플로우] 에만 경계선이 보이지 않도록 수정하였습니다.
- 추가적으로 필요한 곳이 있으면 코멘트 남겨주시면 바로 반영하겠습니다.