### PR TITLE
[fix] 카카오로그인 수정 및 킹피셔 이슈 해결

### DIFF
--- a/KkuMulKum.xcodeproj/project.pbxproj
+++ b/KkuMulKum.xcodeproj/project.pbxproj
@@ -2214,6 +2214,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "꾸물꿈";
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 라이브러리 접근 권한이 필요합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "꾸물꿈은 카메라 권한을 필요로 합니다. 카메라를 통해 자신의 프로필을 즉시 찍어 업로드할 수 있습니다. 허용 안함 시 일부 기능이 동작하지 않을 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -2251,6 +2252,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "꾸물꿈";
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 라이브러리 접근 권한이 필요합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "꾸물꿈은 카메라 권한을 필요로 합니다. 카메라를 통해 자신의 프로필을 즉시 찍어 업로드할 수 있습니다. 허용 안함 시 일부 기능이 동작하지 않을 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/KkuMulKum/Resource/Info.plist
+++ b/KkuMulKum/Resource/Info.plist
@@ -2,15 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>꾸물꿈은 카메라 권한을 필요로 합니다. 카메라를 통해 자신의 프로필을 즉시 찍어 업로드할 수 있습니다. 허용 안함 시 일부 기능이 동작하지 않을 수 있습니다.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
-			<array/>
+			<array>
+				<string>kakao69aeef4a49d5b6772d62efdf1686994c</string>
+			</array>
 		</dict>
 	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageEditViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageEditViewController.swift
@@ -16,6 +16,7 @@ class MyPageEditViewController: BaseViewController {
     private let viewModel: MyPageEditViewModel
     private let disposeBag = DisposeBag()
     private let newProfileImageSubject = PublishSubject<UIImage?>()
+    let profileImageUpdated = PublishSubject<String?>()
     
     init(viewModel: MyPageEditViewModel) {
         self.viewModel = viewModel
@@ -72,6 +73,13 @@ class MyPageEditViewController: BaseViewController {
             skipButtonTap: rootView.skipButton.rx.tap.asObservable(),
             newProfileImage: newProfileImageSubject.asObservable()
         )
+        
+        input.newProfileImage
+            .compactMap { $0 }
+            .subscribe(onNext: { [weak self] image in
+                self?.viewModel.updateProfileImage(image)
+            })
+            .disposed(by: disposeBag)
         
         let output = viewModel.transform(input: input, disposeBag: disposeBag)
         

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageTermsViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageTermsViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 import WebKit
 
+import SnapKit
+
 class MyPageTermsViewController: BaseViewController {
     
     private let viewModel: MyPageViewModel
@@ -26,21 +28,46 @@ class MyPageTermsViewController: BaseViewController {
         let webConfiguration = WKWebViewConfiguration()
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
         webView.uiDelegate = self
-        view = webView
+        view = UIView()
+        view.addSubview(webView)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let myURL = URL(string: "https://arrow-frog-4b9.notion.site/a66033a3ff4a40bfaa6eff0a5bee737d")
-        let myRequest = URLRequest(url: myURL!)
-        webView.load(myRequest)
-    }
-    
-    override func setupView() {
-        super.setupView()
         setupNavigationBarTitle(with: "이용약관")
         setupNavigationBarBackButton()
+        
+        setupConstraints()
+        
+        if let myURL = URL(string: "https://arrow-frog-4b9.notion.site/a66033a3ff4a40bfaa6eff0a5bee737d") {
+            let myRequest = URLRequest(url: myURL)
+            webView.load(myRequest)
+        }
+    }
+    
+    private func setupConstraints() {
+        webView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+        }
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        adjustWebViewContentInset()
+    }
+    
+    private func adjustWebViewContentInset() {
+        let contentInset = UIEdgeInsets(
+            top: 0,
+            left: 0,
+            bottom: view.safeAreaInsets.bottom + (tabBarController?.tabBar.frame.height ?? 0),
+            right: 0
+        )
+        webView.scrollView.contentInset = contentInset
+        webView.scrollView.scrollIndicatorInsets = contentInset
     }
 }
 

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
@@ -140,12 +140,16 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
         updateProfileImage(with: userInfo.profileImageURL)
     }
     
-    private func updateProfileImage(with urlString: String?) {
+    private func updateProfileImage(with urlString: String?, localImage: UIImage? = nil) {
         print("Attempting to update profile image with URL: \(urlString ?? "nil")")
+        if let localImage = localImage {
+            rootView.contentView.profileImageView.image = localImage
+        }
+        
         if let urlString = urlString, let url = URL(string: urlString) {
             rootView.contentView.profileImageView.kf.setImage(
                 with: url,
-                placeholder: UIImage.imgProfile,
+                placeholder: localImage ?? UIImage.imgProfile,
                 options: [
                     .transition(.fade(0.2)),
                     .forceRefresh,
@@ -154,16 +158,18 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
                 completionHandler: { result in
                     switch result {
                     case .success(let value):
-                        print("Profile image loaded successfully. Size: \(value.image.size)")
+                        print("Profile image loaded successfully from server. Size: \(value.image.size)")
                     case .failure(let error):
-                        print("Failed to load profile image: \(error.localizedDescription)")
-                        self.rootView.contentView.profileImageView.image = UIImage.imgProfile
+                        print("Failed to load profile image from server: \(error.localizedDescription)")
+                        if self.rootView.contentView.profileImageView.image == nil {
+                            self.rootView.contentView.profileImageView.image = UIImage.imgProfile
+                        }
                     }
                 }
             )
         } else {
-            print("Invalid URL or nil. Setting default profile image.")
-            rootView.contentView.profileImageView.image = UIImage.imgProfile
+            print("Invalid URL or nil. Using local image or default profile image.")
+            rootView.contentView.profileImageView.image = localImage ?? UIImage.imgProfile
         }
     }
     
@@ -212,7 +218,7 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
                 if let imageDataString = imageDataString,
                    let imageData = Data(base64Encoded: imageDataString),
                    let image = UIImage(data: imageData) {
-                    self?.rootView.contentView.profileImageView.image = image
+                    self?.updateProfileImage(with: nil, localImage: image)
                 }
                 self?.needsUserInfoRefresh = true
             })

--- a/KkuMulKum/Source/Onboarding/Profile/VIewController/ProfileSetupViewController.swift
+++ b/KkuMulKum/Source/Onboarding/Profile/VIewController/ProfileSetupViewController.swift
@@ -50,21 +50,17 @@ class ProfileSetupViewController: BaseViewController {
     }
     
     @objc private func confirmButtonTapped() {
-        Task {
-            let success = await viewModel.uploadProfileImage()
-            if success {
-                DispatchQueue.main.async {
-                    let welcomeVC = WelcomeViewController(
-                        viewModel: WelcomeViewModel(nickname: self.viewModel.nickname)
-                    )
-                    welcomeVC.modalPresentationStyle = .fullScreen
-                    self.present(welcomeVC, animated: true, completion: nil)
-                }
-            }
+        if viewModel.isConfirmButtonEnabled.value {
+            viewModel.uploadProfileImage()
+            navigateToWelcomeScreen()
         }
     }
     
     @objc private func skipButtonTapped() {
+        navigateToWelcomeScreen()
+    }
+    
+    private func navigateToWelcomeScreen() {
         let welcomeVC = WelcomeViewController(
             viewModel: WelcomeViewModel(nickname: viewModel.nickname)
         )

--- a/KkuMulKum/Source/Onboarding/Profile/ViewModel/ProfileSetupViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Profile/ViewModel/ProfileSetupViewModel.swift
@@ -48,43 +48,28 @@ class ProfileSetupViewModel {
         return imageData
     }
     
-    func uploadProfileImage() async -> Bool {
-        print("uploadProfileImage 함수 호출됨")
-        guard let imageData = imageData else {
-            print("이미지 데이터가 없습니다.")
-            serverResponse.value = "이미지 데이터가 없습니다."
-            return false
-        }
-        
-        if imageData.count > maxImageSizeBytes {
-            print("이미지 크기가 최대 허용 크기를 초과합니다.")
-            serverResponse.value = "이미지 크기가 너무 큽니다. 더 작은 이미지를 선택해주세요."
-            return false
-        }
-        
-        print("업로드할 이미지 데이터 크기: \(imageData.count) bytes")
-        
-        let fileName = "profile_image.jpg"
-        let mimeType = "image/jpeg"
-        
-        do {
-            let _: EmptyModel = try await authService.performRequest(
-                .updateProfileImage(
-                    image: imageData,
-                    fileName: fileName,
-                    mimeType: mimeType
-                )
-            )
-            serverResponse.value = "프로필 이미지가 성공적으로 업로드되었습니다."
-            print("프로필 이미지 업로드 성공")
+    func uploadProfileImage() {
+            guard let imageData = imageData else {
+                serverResponse.value = "이미지 데이터가 없습니다."
+                return
+            }
             
-            clearImageCache()
-            return true
-        } catch {
-            handleError(error as? NetworkError ?? .unknownError("알 수 없는 오류가 발생했습니다."))
-            return false
+            Task {
+                do {
+                    let _: EmptyModel = try await authService.performRequest(
+                        .updateProfileImage(
+                            image: imageData,
+                            fileName: "profile_image.jpg",
+                            mimeType: "image/jpeg"
+                        )
+                    )
+                    print("프로필 이미지가 성공적으로 업로드되었습니다.")
+                    clearImageCache()
+                } catch {
+                    print("프로필 이미지 업로드 실패: \(error.localizedDescription)")
+                }
+            }
         }
-    }
     
     private func handleError(_ error: NetworkError) {
         switch error {


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #363 

## 📄 작업 내용
- 카카오로그인 수정 및 킹피셔 오류 해결

## 📚 참고자료
Toss slash 23

## 👀 기타 더 이야기해볼 점
- 카카오 로그인은 앱 배포시 직접 올리고 깃허브에는 올리지 않아 문제를 해결하였습니다.
- 온보딩 로직에서 프로필 등록시 킹피셔로 압축하여 서버에 올리는시간이 약 2초-3초 정도 걸렷는데 해당 기다리는 시간이 앱이 동작을 안한다고 생각하여 QA가 잡혔습니다.
 
- 이를 해결하고자 온보딩 로직에서 이미지를 등록하였을때 이미지 등록직후 화면은 바로 다음화면으로 넘기고 이미지 등록이 완료되었는지 여부는 확인하지 않는방식으로 구현하였습니다. 이미지 등록여부는 마이페이지까지 들어가야 확인할 수 있지만 에러가 있는 코드가 아니고 무결성을 확신할 수 있는 코드라고 생각하기에 해당 로직을 채택하였습니다.
앱에서 마이페이지까지 가는 시간이 아무리 빨라도 2초 이상 걸린다 생각하며 이미지를 받아오는 시간이 이보다 빠를것이기에 (초고화질이 아니라면) 이미지를 불러오는데에도 문제가 없을것입니다. (사실상 비동기를 직접 구현하였다고 보시면 됩니다.)
- 해당 아이디어는 토스의 Slash23 의 뷰 속도 개선하기 영상에서 본것같은데 다시보니 이런게 없네요 어쩃든 Toss Slash 에서 착안한 방법입니다.

- 마이페이지또한 변경이 안되는것이 아닌 이미지를 서버에 킹피셔 압축 -> post -> get 로직을 거치게 되어 2초이상 걸리고 캐시삭제까지 이루어지게 되어 이미지 변경이 안되는것처럼 느껴진것입니다. 이를위해 이미지 전달을 서버에 의존하는것이 아닌 이미지 변경 사항을 Rx로 직접 바인딩하여 이미지 정보를 전달하는 로직으로 변경하였습니다.