### PR TITLE
[fix] 약속 상세 QA 반영

### DIFF
--- a/KkuMulKum/Source/Promise/EditPromise/ViewController/ChooseContentViewController.swift
+++ b/KkuMulKum/Source/Promise/EditPromise/ViewController/ChooseContentViewController.swift
@@ -54,7 +54,22 @@ class ChooseContentViewController: BaseViewController {
         rootView.confirmButton.setTitle("수정하기", style: .body03, color: .white)
         
         for button in self.rootView.levelButtons {
-            button.isSelected = (button.titleLabel?.text == viewModel.dressUpLevel?.value)
+            let levels = ["LV1", "LV2", "LV3", "LV4", "FREE"]
+            
+            if var dressUpLevel = button.titleLabel?.text {
+                if dressUpLevel.contains("마음대로 입고 오기") {
+                    dressUpLevel = "FREE"
+                }
+                else {
+                    if let matched = levels.first(where: {
+                        level in dressUpLevel.replacingOccurrences(of: " ", with: "").contains(level)
+                    }) {
+                        dressUpLevel = matched
+                    }
+                }
+                
+                button.isSelected = (dressUpLevel == viewModel.dressUpLevel?.value)
+            }
         }
             
         for button in self.rootView.penaltyButtons {

--- a/KkuMulKum/Source/Promise/EditPromise/ViewController/ChooseMemberViewController.swift
+++ b/KkuMulKum/Source/Promise/EditPromise/ViewController/ChooseMemberViewController.swift
@@ -76,7 +76,8 @@ class ChooseMemberViewController: BaseViewController {
 private extension ChooseMemberViewController {
     func setupBinding() {
         viewModel.participantList?.bindOnMain(with: self, { owner, members in
-            self.rootView.memberListView.reloadData()
+            owner.rootView.emptyContentView.isHidden = !members.isEmpty
+            owner.rootView.memberListView.reloadData()
         })
     }
     

--- a/KkuMulKum/Source/Promise/PagePromise/ViewController/PromiseViewController.swift
+++ b/KkuMulKum/Source/Promise/PagePromise/ViewController/PromiseViewController.swift
@@ -151,7 +151,6 @@ private extension PromiseViewController {
         viewModel.promiseInfo.bindOnMain(with: self) { owner, info in
             owner.setupNavigationBarTitle(with: info?.promiseName ?? "", isBorderHidden: true)
             
-            owner.promiseInfoViewController.rootView.editButton.isHidden = !(info?.isParticipant ?? false)
             owner.setupPromiseEditButton(isHidden: !(info?.isParticipant ?? false))
             
             owner.promiseInfoViewController.setupContent()

--- a/KkuMulKum/Source/Promise/PromiseInfo/ViewController/PromiseInfoViewController.swift
+++ b/KkuMulKum/Source/Promise/PromiseInfo/ViewController/PromiseInfoViewController.swift
@@ -71,19 +71,38 @@ class PromiseInfoViewController: BaseViewController {
 extension PromiseInfoViewController {
     @objc
     func editButtonDidTap() {
-        let viewController = EditPromiseViewController(
-            viewModel: EditPromiseViewModel(
-                promiseID: viewModel.promiseID,
-                promiseName: viewModel.promiseInfo.value?.promiseName,
-                placeName: viewModel.promiseInfo.value?.placeName,
-                time: viewModel.promiseInfo.value?.time,
-                dressUpLevel: viewModel.promiseInfo.value?.dressUpLevel,
-                penalty: viewModel.promiseInfo.value?.penalty,
-                service: PromiseService()
+        if var dressUpLevel = viewModel.promiseInfo.value?.dressUpLevel {
+            let levels = ["LV1", "LV2", "LV3", "LV4", "FREE"]
+            
+            if dressUpLevel.contains("마음대로 입고 오기") {
+                dressUpLevel = "FREE"
+            }
+            else {
+                if let matched = levels.first(where: {
+                    level in dressUpLevel.replacingOccurrences(of: " ", with: "").contains(level)
+                }) {
+                    dressUpLevel = matched
+                }
+            }
+            
+            let viewController = EditPromiseViewController(
+                viewModel: EditPromiseViewModel(
+                    promiseID: viewModel.promiseID,
+                    promiseName: viewModel.promiseInfo.value?.promiseName,
+                    placeName: viewModel.promiseInfo.value?.placeName,
+                    xCoordinate: viewModel.promiseInfo.value?.x,
+                    yCoordinate: viewModel.promiseInfo.value?.y,
+                    address: viewModel.promiseInfo.value?.address,
+                    roadAddress: viewModel.promiseInfo.value?.roadAddress,
+                    time: viewModel.promiseInfo.value?.time,
+                    dressUpLevel: dressUpLevel,
+                    penalty: viewModel.promiseInfo.value?.penalty,
+                    service: PromiseService()
+                )
             )
-        )
-        
-        navigationController?.pushViewController(viewController, animated: true)
+            
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
     
     func setupBinding() {

--- a/KkuMulKum/Source/Promise/PromiseInfo/ViewController/PromiseInfoViewController.swift
+++ b/KkuMulKum/Source/Promise/PromiseInfo/ViewController/PromiseInfoViewController.swift
@@ -53,6 +53,10 @@ class PromiseInfoViewController: BaseViewController {
     
     override func setupView() {
         view.backgroundColor = .gray0
+        
+        if let isParticipant = viewModel.promiseInfo.value?.isParticipant {
+            rootView.editButton.isHidden = isParticipant
+        }
     }
     
     override func setupDelegate() {
@@ -107,7 +111,6 @@ extension PromiseInfoViewController {
     
     func setupBinding() {
         viewModel.isPastDue.bindOnMain(with: self) { owner, isPastDue in
-            
             owner.rootView.editButton.isHidden = isPastDue
         }
         

--- a/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyStatusView.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyStatusView.swift
@@ -31,6 +31,7 @@ class ReadyStatusView: BaseView {
     
     let popUpImageView: UIImageView = UIImageView(image: .imgTextPopup).then {
         $0.contentMode = .scaleAspectFit
+        $0.isHidden = true
     }
     
     let ourReadyStatusCollectionView: UICollectionView = UICollectionView(

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -428,20 +428,23 @@ extension ReadyStatusViewController {
     
     @objc
     func readyStartButtonDidTap() {
-        viewModel.fetchPromiseParticipantList()
-        viewModel.updatePreparationStatus()
+        viewModel.updatePreparationStatus {
+            self.viewModel.fetchPromiseParticipantList()
+        }
     }
     
     @objc
     func moveStartButtonDidTap() {
-        viewModel.fetchPromiseParticipantList()
-        viewModel.updateDepartureStatus()
+        viewModel.updateDepartureStatus {
+            self.viewModel.fetchPromiseParticipantList()
+        }
     }
     
     @objc
     func arrivalButtonDidTap() {
-        viewModel.fetchPromiseParticipantList()
-        viewModel.updateArrivalStatus()
+        viewModel.updateArrivalStatus {
+            self.viewModel.fetchPromiseParticipantList()
+        }
     }
     
     @objc
@@ -521,15 +524,19 @@ extension ReadyStatusViewController: UICollectionViewDataSource {
             cell.profileImageView.kf.setImage(with: imageURL, placeholder: UIImage.imgProfile)
         }
         
-        switch viewModel.myReadyProgressStatus.value {
-        case .none:
+        switch viewModel.participantsInfo.value?[indexPath.row].state {
+        case "꾸물중":
             cell.readyStatusButton.setupButton("꾸물중", .none)
-        case .ready:
+        case "준비중":
             cell.readyStatusButton.setupButton("준비중", .ready)
-        case .move:
+        case "이동중":
             cell.readyStatusButton.setupButton("이동중", .move)
-        case .done:
+        case "도착":
             cell.readyStatusButton.setupButton("도착", .done)
+        case .none:
+            return cell
+        case .some(_):
+            return cell
         }
         
         return cell

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -97,7 +97,10 @@ class ReadyStatusViewController: BaseViewController {
 extension ReadyStatusViewController {
     func setupBinding() {
         viewModel.promiseInfo.bindOnMain(with: self) { owner, model in
-            owner.rootView.myReadyStatusProgressView.isUserInteractionEnabled = (model?.isParticipant ?? false)
+            if let isParticipant = model?.isParticipant {
+                owner.rootView.myReadyStatusProgressView.isUserInteractionEnabled = isParticipant
+                owner.rootView.enterReadyButtonView.isUserInteractionEnabled = isParticipant
+            }
         }
         
         viewModel.myReadyStatus.bind(with: self) {

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -102,6 +102,10 @@ extension ReadyStatusViewController {
                 owner.rootView.myReadyStatusProgressView.isUserInteractionEnabled = isParticipant
                 owner.rootView.enterReadyButtonView.isUserInteractionEnabled = isParticipant
                 owner.updateReadyInfoView(flag: isParticipant)
+                
+                if !isParticipant {
+                    owner.rootView.myReadyStatusProgressView.readyStartButton.setupButton("준비 시작", .none)
+                }
             }
         }
         

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -99,6 +99,7 @@ extension ReadyStatusViewController {
         viewModel.promiseInfo.bindOnMain(with: self) { owner, model in
             owner.rootView.myReadyStatusProgressView.isUserInteractionEnabled = (model?.isParticipant ?? false)
         }
+        
         viewModel.myReadyStatus.bind(with: self) {
             owner,
             model in
@@ -192,6 +193,8 @@ extension ReadyStatusViewController {
         
         viewModel.myReadyProgressStatus.bindOnMain(with: self) { owner, status in
             owner.updateReadyStartButton()
+            
+            self.rootView.ourReadyStatusCollectionView.reloadData()
         }
         
         viewModel.participantsInfo.bindOnMain(with: self) { owner, participants in
@@ -511,15 +514,15 @@ extension ReadyStatusViewController: UICollectionViewDataSource {
             cell.profileImageView.kf.setImage(with: imageURL, placeholder: UIImage.imgProfile)
         }
         
-        switch viewModel.participantsInfo.value?[indexPath.row].state {
-        case "도착":
-            cell.readyStatusButton.setupButton("도착", .done)
-        case "이동중":
-            cell.readyStatusButton.setupButton("이동중", .move)
-        case "준비중":
-            cell.readyStatusButton.setupButton("준비중", .ready)
-        default:
+        switch viewModel.myReadyProgressStatus.value {
+        case .none:
             cell.readyStatusButton.setupButton("꾸물중", .none)
+        case .ready:
+            cell.readyStatusButton.setupButton("준비중", .ready)
+        case .move:
+            cell.readyStatusButton.setupButton("이동중", .move)
+        case .done:
+            cell.readyStatusButton.setupButton("도착", .done)
         }
         
         return cell

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -98,51 +98,47 @@ class ReadyStatusViewController: BaseViewController {
 extension ReadyStatusViewController {
     func setupBinding() {
         viewModel.promiseInfo.bindOnMain(with: self) { owner, model in
-            if let isParticipant = model?.isParticipant {
-                owner.rootView.enterReadyButtonView.isUserInteractionEnabled = isParticipant
-                
-                if !isParticipant {
-                    owner.updateReadyInfoView(flag: false)
-                    owner.rootView.myReadyStatusProgressView.readyStartButton.setupButton("준비 시작", .none)
-                }
+            guard let isParticipant = model?.isParticipant else { return }
+
+            owner.rootView.enterReadyButtonView.isUserInteractionEnabled = isParticipant
+
+            if !isParticipant {
+                owner.updateReadyInfoView(flag: false)
+                owner.rootView.myReadyStatusProgressView.readyStartButton.setupButton("준비 시작", .none)
             }
         }
         
-        viewModel.myReadyStatus.bindOnMain(with: self) {
-            owner,
-            model in
-            if let status = model {
-                /// 준비 시간을 계산해 UI에 표시
-                owner.viewModel.calculateDuration()
-                owner.viewModel.calculateStartTime()
-                
-                /// myReadyStatus의 바인딩 부분에 조건을 통해 myReadyProgressStatus 값을 업데이트
-                if status.preparationStartAt == nil {
-                    owner.viewModel.myReadyProgressStatus.value = .none
-                }
-                else if status.departureAt == nil {
-                    owner.viewModel.myReadyProgressStatus.value = .ready
-                }
-                else if status.arrivalAt == nil {
-                    owner.viewModel.myReadyProgressStatus.value = .move
-                }
-                else {
-                    owner.viewModel.myReadyProgressStatus.value = .done
-                }
-                
-                /// 준비하기 버튼과 준비 정보 화면 중 어떤 걸 표시할지 결정
-                if status.preparationTime == nil {
-                    owner.updateReadyInfoView(flag: false)
-                    return
-                }
-                
-                owner.updateReadyInfoView(flag: true)
+        viewModel.myReadyStatus.bindOnMain(with: self) { owner, model in
+            guard let status = model else { return }
+            
+            /// 준비 시간을 계산해 UI에 표시
+            owner.viewModel.calculateDuration()
+            owner.viewModel.calculateStartTime()
+            
+            /// myReadyStatus의 바인딩 부분에 조건을 통해 myReadyProgressStatus 값을 업데이트
+            if status.preparationStartAt == nil {
+                owner.viewModel.myReadyProgressStatus.value = .none
             }
+            else if status.departureAt == nil {
+                owner.viewModel.myReadyProgressStatus.value = .ready
+            }
+            else if status.arrivalAt == nil {
+                owner.viewModel.myReadyProgressStatus.value = .move
+            }
+            else {
+                owner.viewModel.myReadyProgressStatus.value = .done
+            }
+            
+            /// 준비하기 버튼과 준비 정보 화면 중 어떤 걸 표시할지 결정
+            if status.preparationTime == nil {
+                owner.updateReadyInfoView(flag: false)
+                return
+            }
+            
+            owner.updateReadyInfoView(flag: true)
         }
         
-        viewModel.moveDuration.bind(with: self) {
-            owner,
-            moveTime in
+        viewModel.moveDuration.bind(with: self) { owner, moveTime in
             owner.rootView.readyPlanInfoView.requestMoveTimeLabel.setText(
                 "이동 소요 시간: \(moveTime)",
                 style: .label02,
@@ -177,9 +173,7 @@ extension ReadyStatusViewController {
             }
         }
         
-        viewModel.moveStartTime.bind(with: self) {
-            owner,
-            moveStartTime in
+        viewModel.moveStartTime.bind(with: self) { owner, moveStartTime in
             DispatchQueue.main.async {
                 owner.rootView.readyPlanInfoView.readyTimeLabel.setText(
                     "\(owner.viewModel.readyStartTime.value)에 준비하고,\n\(moveStartTime)에 이동을 시작해야 해요",
@@ -196,8 +190,7 @@ extension ReadyStatusViewController {
         
         viewModel.myReadyProgressStatus.bindOnMain(with: self) { owner, status in
             owner.updateReadyStartButton()
-            
-            self.rootView.ourReadyStatusCollectionView.reloadData()
+            owner.rootView.ourReadyStatusCollectionView.reloadData()
         }
         
         viewModel.participantsInfo.bindOnMain(with: self) { owner, participants in
@@ -211,7 +204,7 @@ extension ReadyStatusViewController {
         }
         
         viewModel.isLate.bindOnMain(with: self) { owner, status in
-            self.updatePopUpImageView()
+            owner.updatePopUpImageView()
         }
     }
     
@@ -424,22 +417,22 @@ extension ReadyStatusViewController {
     
     @objc
     func readyStartButtonDidTap() {
-        viewModel.updatePreparationStatus {
-            self.viewModel.fetchPromiseParticipantList()
+        viewModel.updatePreparationStatus { [weak self] in
+            self?.viewModel.fetchPromiseParticipantList()
         }
     }
     
     @objc
     func moveStartButtonDidTap() {
-        viewModel.updateDepartureStatus {
-            self.viewModel.fetchPromiseParticipantList()
+        viewModel.updateDepartureStatus { [weak self] in
+            self?.viewModel.fetchPromiseParticipantList()
         }
     }
     
     @objc
     func arrivalButtonDidTap() {
-        viewModel.updateArrivalStatus {
-            self.viewModel.fetchPromiseParticipantList()
+        viewModel.updateArrivalStatus { [weak self] in
+            self?.viewModel.fetchPromiseParticipantList()
         }
     }
     

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -45,6 +45,7 @@ class ReadyStatusViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        viewModel.fetchPromiseInfo()
         viewModel.fetchMyReadyStatus()
         viewModel.fetchPromiseParticipantList()
     }
@@ -100,44 +101,43 @@ extension ReadyStatusViewController {
             if let isParticipant = model?.isParticipant {
                 owner.rootView.myReadyStatusProgressView.isUserInteractionEnabled = isParticipant
                 owner.rootView.enterReadyButtonView.isUserInteractionEnabled = isParticipant
+                owner.updateReadyInfoView(flag: isParticipant)
             }
         }
         
-        viewModel.myReadyStatus.bind(with: self) {
+        viewModel.myReadyStatus.bindOnMain(with: self) {
             owner,
             model in
-            DispatchQueue.main.async {
-                guard let model else {
-                    owner.updateReadyInfoView(flag: false)
-                    return
-                }
-                
-                /// 준비 시간을 계산해 UI에 표시
-                owner.viewModel.calculateDuration()
-                owner.viewModel.calculateStartTime()
-                
-                /// myReadyStatus의 바인딩 부분에 조건을 통해 myReadyProgressStatus 값을 업데이트
-                if model.preparationStartAt == nil {
-                    owner.viewModel.myReadyProgressStatus.value = .none
-                }
-                else if model.departureAt == nil {
-                    owner.viewModel.myReadyProgressStatus.value = .ready
-                }
-                else if model.arrivalAt == nil {
-                    owner.viewModel.myReadyProgressStatus.value = .move
-                }
-                else {
-                    owner.viewModel.myReadyProgressStatus.value = .done
-                }
-                
-                /// 준비하기 버튼과 준비 정보 화면 중 어떤 걸 표시할지 결정
-                if model.preparationTime == nil {
-                    owner.updateReadyInfoView(flag: false)
-                    return
-                }
-                
-                owner.updateReadyInfoView(flag: true)
+            guard let model else {
+                owner.updateReadyInfoView(flag: false)
+                return
             }
+            
+            /// 준비 시간을 계산해 UI에 표시
+            owner.viewModel.calculateDuration()
+            owner.viewModel.calculateStartTime()
+            
+            /// myReadyStatus의 바인딩 부분에 조건을 통해 myReadyProgressStatus 값을 업데이트
+            if model.preparationStartAt == nil {
+                owner.viewModel.myReadyProgressStatus.value = .none
+            }
+            else if model.departureAt == nil {
+                owner.viewModel.myReadyProgressStatus.value = .ready
+            }
+            else if model.arrivalAt == nil {
+                owner.viewModel.myReadyProgressStatus.value = .move
+            }
+            else {
+                owner.viewModel.myReadyProgressStatus.value = .done
+            }
+            
+            /// 준비하기 버튼과 준비 정보 화면 중 어떤 걸 표시할지 결정
+            if model.preparationTime == nil {
+                owner.updateReadyInfoView(flag: false)
+                return
+            }
+            
+            owner.updateReadyInfoView(flag: true)
         }
         
         viewModel.moveDuration.bind(with: self) {

--- a/KkuMulKum/Source/Promise/Tardy/View/ArriveView.swift
+++ b/KkuMulKum/Source/Promise/Tardy/View/ArriveView.swift
@@ -55,12 +55,12 @@ class ArriveView: BaseView {
         }
         
         mainTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(giftImageView.snp.bottom).offset(36)
+            $0.top.equalTo(giftImageView.snp.bottom).offset(30)
             $0.centerX.equalToSuperview()
         }
         
         subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(mainTitleLabel.snp.bottom).offset(17)
+            $0.top.equalTo(mainTitleLabel.snp.bottom).offset(4)
             $0.centerX.equalToSuperview()
         }
         

--- a/KkuMulKum/Source/Promise/Tardy/ViewController/TardyViewController.swift
+++ b/KkuMulKum/Source/Promise/Tardy/ViewController/TardyViewController.swift
@@ -45,9 +45,9 @@ class TardyViewController: BaseViewController {
     // MARK: - Setup
     
     override func setupView() {
-        view.addSubviews(tardyView, arriveView)
+        view.addSubviews(arriveView, tardyView)
         
-        [tardyView, arriveView].forEach {
+        [arriveView, tardyView].forEach {
             $0.snp.makeConstraints {
                 $0.edges.equalToSuperview()
             }
@@ -66,8 +66,6 @@ private extension TardyViewController {
     func setupBinding() {
         /// 시간이 지나고 지각자가 없을 때 arriveView로 띄워짐
         viewModel.isPastDue.bindOnMain(with: self) { owner, isPastDue in
-            owner.tardyView.tardyCollectionView.isHidden = !isPastDue
-            owner.tardyView.tardyEmptyView.isHidden = isPastDue
             owner.tardyView.finishMeetingButton.isEnabled = (isPastDue && (owner.viewModel.promiseInfo.value?.isParticipant ?? false))
         }
         
@@ -80,10 +78,13 @@ private extension TardyViewController {
         }
         
         viewModel.hasTardy.bindOnMain(with: self) { owner, hasTardy in
-            let flag = hasTardy && owner.viewModel.isPastDue.value
-
-            owner.arriveView.isHidden = !flag
-            owner.tardyView.isHidden = flag
+            let isPastDue = owner.viewModel.isPastDue.value
+            let arriveHideFlag = !(isPastDue && !hasTardy)
+            
+            owner.arriveView.isHidden = arriveHideFlag
+            owner.tardyView.isHidden = !arriveHideFlag
+            owner.tardyView.tardyCollectionView.isHidden = !isPastDue
+            owner.tardyView.tardyEmptyView.isHidden = isPastDue
         }
         
         viewModel.comers.bind(with: self) { owner, comers in

--- a/KkuMulKum/Source/Promise/ViewModel/PromiseViewModel.swift
+++ b/KkuMulKum/Source/Promise/ViewModel/PromiseViewModel.swift
@@ -342,7 +342,7 @@ extension PromiseViewModel {
                     return
                 }
                 
-                hasTardy.value = data.lateComers.isEmpty
+                hasTardy.value = !(data.lateComers.isEmpty)
                 isPastDue.value = data.isPastDue
                 penalty.value = data.penalty
                 comers.value = data.lateComers

--- a/KkuMulKum/Source/Promise/ViewModel/PromiseViewModel.swift
+++ b/KkuMulKum/Source/Promise/ViewModel/PromiseViewModel.swift
@@ -265,7 +265,7 @@ extension PromiseViewModel {
     }
     
     /// 준비 시작 업데이트 API 구현 함수
-    func updatePreparationStatus() {
+    func updatePreparationStatus(completion: @escaping () -> Void) {
         Task {
             do {
                 let responseBody = try await service.updatePreparationStatus(
@@ -281,12 +281,14 @@ extension PromiseViewModel {
                 myReadyProgressStatus.value = .ready
                 
                 self.checkLate(tappedButton: .ready)
+                
+                completion()
             }
         }
     }
     
     /// 이동 시작 업데이트 API 구현 함수
-    func updateDepartureStatus() {
+    func updateDepartureStatus(completion: @escaping () -> Void) {
         Task {
             do {
                 let responseBody = try await service.updateDepartureStatus(
@@ -302,12 +304,14 @@ extension PromiseViewModel {
                 myReadyProgressStatus.value = .move
                 
                 self.checkLate(tappedButton: .move)
+                
+                completion()
             }
         }
     }
     
     /// 도착 완료 업데이트 API 구현 함수
-    func updateArrivalStatus() {
+    func updateArrivalStatus(completion: @escaping () -> Void) {
         Task {
             do {
                 let responseBody = try await service.updateArrivalStatus(
@@ -321,6 +325,8 @@ extension PromiseViewModel {
                 }
                 
                 myReadyProgressStatus.value = .done
+                
+                completion()
             }
         }
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #367

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 약속 상세 QA 내용 반영했습니다.
- 우리들의 준비 현황 CollectionView의 셀 상태가 버튼을 눌렀을 때 업데이트 되지 않는 문제를 해결했습니다.
- 지각 꾸물이 뷰 분기 처리 시 앱이 충돌하는 문제를 해결했습니다. API가 호출되며 뷰가 아예 새로 추가되는 로직과 오토레이아웃이 충돌하는 문제였던 것 같아요. isHidden으로 처리했습니다.
- 약속 수정하기에서 아무것도 수정하지 않고 수정하기 버튼을 눌렀을 때 서버 통신이 되지 않는 문제 해결했습니다.
- 준비 현황 뷰에서 시간 입력 컴포넌트가 랜덤하게 나오는 문제 해결했습니다.
- 지각 꾸물이 뷰 분기 처리 추가했습니다.

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
