### PR TITLE
[refactor] QA 관련 api 호출 로직 수정

### DIFF
--- a/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
+++ b/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
@@ -193,7 +193,9 @@ final class HomeViewModel {
                 let placeName = self.nearestPromise.value?.data?.placeName ?? ""
                 todayPlaceName.value = placeName.count > 14 ? String(placeName.prefix(14)) + "..." : placeName
                 
-                requestMyReadyStatus()
+                if let _ = nearestPromise.value?.data {
+                    requestMyReadyStatus()
+                }
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #376 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈 화면에 들어갈 때마다 `/api/v1/promises/1/status`으로 계속하여 요청을 보내는 것을 방지하기 위해 오늘의 약속이 있을 때만 준비 상태 api를 호출하도록 수정하였습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
이것이 찐마지막 수정사항이길 바라며 pr 올려버릴게요 ~,,