### PR TITLE
[fix] 모임 상세 화면 최종 QA 반영

### DIFF
--- a/KkuMulKum/Source/MeetingInfo/Cell/MeetingPromiseCell.swift
+++ b/KkuMulKum/Source/MeetingInfo/Cell/MeetingPromiseCell.swift
@@ -112,7 +112,7 @@ extension MeetingPromiseCell {
         nameLabel.setText(model.name, style: .body03, color: model.state.nameTextColor)
         dateLabel.setText(model.dateText, style: .body06, color: model.state.otherTextColor)
         timeLabel.setText(model.timeText, style: .body06, color: model.state.otherTextColor)
-        placeLabel.setText(model.placeName, style: .body06, color: model.state.otherTextColor)
+        placeLabel.setText(model.placeName, style: .body06, color: model.state.otherTextColor, isSingleLine: true)
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #384

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 주소의 길이가 길 때, `...`으로 생략되어 표현되게끔 수정하였습니다.

|    구현 내용    |   IPhone 11 pro max   |
| :-------------: | :----------: |
| 주소 생략 | <img src = "https://github.com/user-attachments/assets/256288bf-3e54-4332-8577-d52260ea6d7a" width ="250"> |