### PR TITLE
[refactor] ObservablePattern 다중 구독 구현하기

### DIFF
--- a/KkuMulKum/Resource/ObservablePattern/ObservablePattern.swift
+++ b/KkuMulKum/Resource/ObservablePattern/ObservablePattern.swift
@@ -10,42 +10,61 @@ import Foundation
 class ObservablePattern<T> {
     var value: T {
         didSet {
-            listener?(value)
+            notifyListeners(value)
         }
     }
     
-    private var listener: ((T) -> Void)?
+    typealias Listener = (T) -> Void
+    
+    private var listeners: [Listener] = []
     
     init(_ value: T) {
         self.value = value
     }
     
-    func bind(_ listener: @escaping (T) -> Void) {
-        self.listener = listener
-    }
-    
-    func bind<Object: AnyObject>(with object: Object, _ listener: @escaping (Object, T) -> Void) {
-        self.listener = { [weak object] value in
-            guard let object else { return }
-            listener(object, value)
+    private func notifyListeners(_ value: T) {
+        for listener in listeners {
+            listener(value)
         }
     }
     
+    func bind(_ listener: @escaping (T) -> Void) {
+        listeners.append(listener)
+        
+        listener(value)
+    }
+    
+    func bind<Object: AnyObject>(with object: Object, _ listener: @escaping (Object, T) -> Void) {
+        listeners.append { [weak object] value in
+            guard let object else { return }
+            listener(object, value)
+        }
+        
+        listener(object, value)
+    }
+    
     func bindOnMain(_ listener: @escaping (T) -> Void) {
-        self.listener = { value in
+        listeners.append { value in
             DispatchQueue.main.async {
                 listener(value)
             }
         }
+        
+        DispatchQueue.main.async {
+            listener(self.value)
+        }
     }
     
     func bindOnMain<Object: AnyObject>(with object: Object, _ listener: @escaping (Object, T) -> Void) {
-        self.listener = { [weak object] value in
+        listeners.append { [weak object] value in
             guard let object else { return }
             DispatchQueue.main.async {
                 listener(object, value)
             }
         }
+        
+        DispatchQueue.main.async {
+            listener(object, self.value)
+        }
     }
 }
-

--- a/KkuMulKum/Source/Promise/ServiceProtocol/PromiseServiceProtocol.swift
+++ b/KkuMulKum/Source/Promise/ServiceProtocol/PromiseServiceProtocol.swift
@@ -26,4 +26,3 @@ protocol PromiseServiceProtocol {
     func deletePromise(promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
     func exitPromise(promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
 }
-


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #386

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Observable Pattern 이 다중 구독이 가능하도록 수정하였습니다.
- 여러 상태 값이 공유되어야 하는 유진이를 고려한 수정입니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### Observable Pattern의 다중 구독
- 지금의 구현은 단일 구독만 가능하기 때문에, 기존의 구독에서 새로운 구독이 생기면 기존 구독은 덮여씌워집니다.
- 배열로써, 다중 구독이 가능하도록 하였습니다.
- 간단하게나마, 동작을 확인하였지만 시간이 남으시다면, 현재 브랜치에서 간단한 QA 부탁드리겠습니다. 
