### PR TITLE
[fix] 최종 QA 반영

### DIFF
--- a/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyStatusProgressView.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/View/ReadyStatusProgressView.swift
@@ -36,7 +36,7 @@ class ReadyStatusProgressView: BaseView {
     }
     
     let readyStartTitleLabel: UILabel = UILabel().then {
-        $0.setText("준비를 시작 시 눌러주세요", style: .label02, color: .gray5)
+        $0.setText("준비 시작 시 눌러주세요", style: .label02, color: .gray5)
     }
     
     let moveStartTimeLabel: UILabel = UILabel().then {
@@ -59,7 +59,7 @@ class ReadyStatusProgressView: BaseView {
     }
     
     let moveStartTitleLabel: UILabel = UILabel().then {
-        $0.setText("이동을 시작 시 눌러주세요", style: .label02, color: .gray5)
+        $0.setText("이동 시작 시 눌러주세요", style: .label02, color: .gray5)
         $0.isHidden = true
     }
     
@@ -83,7 +83,7 @@ class ReadyStatusProgressView: BaseView {
     }
     
     let arrivalTitleLabel: UILabel = UILabel().then {
-        $0.setText("도착 시작 시 눌러주세요", style: .label02, color: .gray5)
+        $0.setText("도착 완료 시 눌러주세요", style: .label02, color: .gray5)
         $0.isHidden = true
     }
     

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -204,6 +204,15 @@ extension ReadyStatusViewController {
                     $0.statusProgressView.setProgress(1, animated: false)
                 }
             }
+            
+            owner.rootView.popUpImageView.do {
+                switch state {
+                case .none, .ready, .move:
+                    $0.isHidden = false
+                case .done:
+                    $0.isHidden = true
+                }
+            }
         }
         
         viewModel.requestReadyTime.bindOnMain(with: self) { owner, time in

--- a/KkuMulKum/Source/Promise/ViewModel/PromiseViewModel.swift
+++ b/KkuMulKum/Source/Promise/ViewModel/PromiseViewModel.swift
@@ -157,7 +157,10 @@ extension PromiseViewModel {
         guard let promiseDate = dateFormatter.date(from: promiseTime) else { return promiseTime }
         
         let timeFormatter = DateFormatter()
-        timeFormatter.dateFormat = "M월 d일 a H:mm"
+        timeFormatter.dateFormat = "M월 d일 a h:mm"
+        timeFormatter.locale = Locale(identifier: "ko_KR")
+        timeFormatter.amSymbol = "AM"
+        timeFormatter.pmSymbol = "PM"
         
         return timeFormatter.string(from: promiseDate)
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #392 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 준비 현황 플로우 텍스트를 수정했습니다.
- 꾸물거릴 시간이 없어요! 팝업을 도착 완료 시에만 숨겨지도록 구현했습니다.
- 약속 정보 뷰 시간 표현 형식을 12시간 형식으로 교체했습니다.

|    구현 내용    |   IPhone 15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/24cbe5c7-e7ba-4d53-a996-2450cbedccf3" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 꾸물거릴 시간이 없어요! 팝업

- 현재 ViewModel에서 서버로부터 받아오는 `preperationStartAt`, `departureAt`, `arrivalAt` 값 유무에 따라 나의 준비 상태를 `none`, `ready`, `move`, `done`으로 바인딩하도록 처리해두었습니다.
- 그래서 팝업 숨김 처리는 그냥 state 케이스에 나누어 처리하는 방식으로 구현했습니다. 이후 실시간으로 지각 여부를 판단할 때도 이 방식을 조금 더 디벨롭하는 식으로 가져갈 것 같습니다.

<details>
<summary>ReadyStatusViewController.swift</summary>

```swift
             owner.rootView.popUpImageView.do {
                switch state {
                case .none, .ready, .move:
                    $0.isHidden = false
                case .done:
                    $0.isHidden = true
                }
            }
```
</details>
