### PR TITLE
[Fix] 최종 QA 반영

### DIFF
--- a/KkuMulKum.xcodeproj/project.pbxproj
+++ b/KkuMulKum.xcodeproj/project.pbxproj
@@ -2225,7 +2225,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = KkuMulKum.yizihn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2267,7 +2267,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = KkuMulKum.yizihn;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/KkuMulKum/Resource/Info.plist
+++ b/KkuMulKum/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
@@ -120,7 +120,6 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
             })
             .disposed(by: disposeBag)
         
-        
         viewModel.userInfo
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] userInfo in

--- a/KkuMulKum/Source/MyPage/ViewModel/MyPageEditViewModel.swift
+++ b/KkuMulKum/Source/MyPage/ViewModel/MyPageEditViewModel.swift
@@ -16,16 +16,12 @@ class MyPageEditViewModel: ViewModelType {
     private let userInfo = BehaviorRelay<LoginUserModel?>(value: nil)
     let profileImageUpdated = PublishSubject<String?>()
     
-    
     struct Input {
-        let profileImageTap: Observable<Void>
         let confirmButtonTap: Observable<Void>
         let skipButtonTap: Observable<Void>
-        let newProfileImage: Observable<UIImage?>
     }
     
     struct Output {
-        let profileImage: Driver<UIImage?>
         let isConfirmButtonEnabled: Driver<Bool>
         let serverResponse: Driver<String?>
         let userInfo: Driver<LoginUserModel?>
@@ -37,95 +33,12 @@ class MyPageEditViewModel: ViewModelType {
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
-        let imageDataRelay = BehaviorRelay<Data?>(value: nil)
         let serverResponseRelay = PublishRelay<String?>()
         
-        input.newProfileImage
-            .compactMap { $0?.jpegData(compressionQuality: 0.8) }
-            .do(onNext: { data in
-                print("New profile image data size: \(data.count) bytes")
-            })
-            .bind(to: imageDataRelay)
-            .disposed(by: disposeBag)
-        
-        let profileImage = imageDataRelay
-            .map { data -> UIImage? in
-                guard let data = data else { return UIImage.imgProfile }
-                return UIImage(data: data)
-            }
-            .asDriver(onErrorJustReturn: UIImage.imgProfile)
-        
-        let isConfirmButtonEnabled = imageDataRelay
-            .map { $0 != nil }
-            .asDriver(onErrorJustReturn: false)
-        
-        input.confirmButtonTap
-            .withLatestFrom(imageDataRelay)
-            .flatMapLatest { [weak self] imageData -> Observable<String> in
-                guard let self = self, let imageData = imageData else {
-                    print("No image data available for upload")
-                    return .just("이미지 데이터가 없습니다.")
-                }
-                return Observable.create { observer in
-                    Task {
-                        do {
-                            print("Attempting to upload image data of size: \(imageData.count) bytes")
-                            let _: EmptyModel = try await self.authService.performRequest(
-                                .updateProfileImage(
-                                    image: imageData,
-                                    fileName: "profile_image.jpg",
-                                    mimeType: "image/jpeg"
-                                )
-                            )
-                            print("Profile image upload successful")
-                            self.profileImageUpdated.onNext(imageData.base64EncodedString())
-                            observer.onNext("프로필 이미지가 성공적으로 업로드되었습니다.")
-                            observer.onCompleted()
-                        } catch {
-                            let networkError = error as? NetworkError ?? .unknownError("알 수 없는 오류가 발생했습니다.")
-                            print("Profile image upload failed: \(networkError)")
-                            observer.onNext(self.handleError(networkError))
-                            observer.onCompleted()
-                        }
-                    }
-                    return Disposables.create()
-                }
-            }
-            .bind(to: serverResponseRelay)
-            .disposed(by: disposeBag)
-        
-        input.skipButtonTap
-            .flatMapLatest { [weak self] _ -> Observable<String> in
-                guard let self = self else { return .just("오류가 발생했습니다.") }
-                return Observable.create { observer in
-                    Task {
-                        do {
-                            let defaultImageData = UIImage.imgProfile.jpegData(compressionQuality: 1.0) ?? Data()
-                            let _: EmptyModel = try await self.authService.performRequest(
-                                .updateProfileImage(
-                                    image: defaultImageData,
-                                    fileName: "default_profile.jpg",
-                                    mimeType: "image/jpeg"
-                                )
-                            )
-                            self.profileImageUpdated.onNext(nil)
-                            observer.onNext("프로필 이미지가 기본 이미지로 변경되었습니다.")
-                            observer.onCompleted()
-                        } catch {
-                            let networkError = error as? NetworkError ?? .unknownError("알 수 없는 오류가 발생했습니다.")
-                            observer.onNext(self.handleError(networkError))
-                            observer.onCompleted()
-                        }
-                    }
-                    return Disposables.create()
-                }
-            }
-            .bind(to: serverResponseRelay)
-            .disposed(by: disposeBag)
+        let isConfirmButtonEnabled = BehaviorRelay<Bool>(value: false)
         
         return Output(
-            profileImage: profileImage,
-            isConfirmButtonEnabled: isConfirmButtonEnabled,
+            isConfirmButtonEnabled: isConfirmButtonEnabled.asDriver(),
             serverResponse: serverResponseRelay.asDriver(onErrorJustReturn: nil),
             userInfo: userInfo.asDriver()
         )
@@ -152,7 +65,29 @@ class MyPageEditViewModel: ViewModelType {
             } catch {
                 let networkError = error as? NetworkError ?? .unknownError("오류 발생.")
                 print("Profile image upload failed: \(networkError)")
-                    self.profileImageUpdated.onNext(nil)
+                self.profileImageUpdated.onNext(nil)
+            }
+        }
+    }
+    
+    func setDefaultProfileImage() {
+        Task {
+            do {
+                let defaultImageData = UIImage.imgProfile.jpegData(compressionQuality: 1.0) ?? Data()
+                let _: EmptyModel = try await self.authService.performRequest(
+                    .updateProfileImage(
+                        image: defaultImageData,
+                        fileName: "default_profile.jpg",
+                        mimeType: "image/jpeg"
+                    )
+                )
+                DispatchQueue.main.async { [weak self] in
+                    self?.profileImageUpdated.onNext(nil)
+                }
+            } catch {
+                let networkError = error as? NetworkError ?? .unknownError("오류 발생.")
+                print("Default profile image upload failed: \(networkError)")
+                self.profileImageUpdated.onNext(nil)
             }
         }
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #394 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 어쩌구저쩌구

|    구현 내용    |   IPhone 15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/8b76c072-b0be-4104-bad9-8e83d0b287a4" width ="250"> |



## 💻 주요 코드 설명
### 설명할 코드 주제 또는 기능

MyPageEditViewController:

기존 `publisher`로 전달주던 코드에서 `selectedImage` 변수를 추가하여 선택된 이미지를 임시로 저장하게 수정했습니다
`handleConfirmButtonTap` 메소드를 추가하여 '수정하기' 버튼을 눌렀을 때만 이미지를 업데이트 하게 수정했습니다
그리고 이미지 선택 시 rootView.profileImageView.image를 업데이트합니다
'수정하기' 버튼을 활성화하는 로직을 추가했습니다.


MyPageEditViewModel:

`newProfileImage` 옵저버블 대신 `updateProfileImage` 메소드를 직접 호출하도록 변경했습니다.
`setDefaultProfileImage` 메소드를 추가하여 기본 프로필 이미지 설정을 처리합니다.

<details>
<summary>해당 코드가 있는 파일명</summary>

