### PR TITLE
[Feat] 자동로그인 Reactorkit - pulse 도입

### DIFF
--- a/KkuMulKum.xcodeproj/project.pbxproj
+++ b/KkuMulKum.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		789D73AF2C46D99B00C7077D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 789D73AE2C46D99B00C7077D /* GoogleService-Info.plist */; };
 		789D73B32C47CC6D00C7077D /* LocalNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789D73B22C47CC6D00C7077D /* LocalNotificationManager.swift */; };
 		789D73BE2C47FE0F00C7077D /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789D73BD2C47FE0F00C7077D /* AuthInterceptor.swift */; };
+		78AA9F1C2D6CC667001F1BCE /* Pulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA9F1B2D6CC667001F1BCE /* Pulse.swift */; };
 		78AED1342C3D951F000AD80A /* NicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AED1332C3D951F000AD80A /* NicknameViewController.swift */; };
 		78AED1372C3D98D1000AD80A /* NicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AED1362C3D98D1000AD80A /* NicknameView.swift */; };
 		78B9286C2C29402C006D9942 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B9286B2C29402C006D9942 /* AppDelegate.swift */; };
@@ -300,6 +301,7 @@
 		789D73B02C46DACD00C7077D /* KkuMulKum.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KkuMulKum.entitlements; sourceTree = "<group>"; };
 		789D73B22C47CC6D00C7077D /* LocalNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationManager.swift; sourceTree = "<group>"; };
 		789D73BD2C47FE0F00C7077D /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
+		78AA9F1B2D6CC667001F1BCE /* Pulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pulse.swift; sourceTree = "<group>"; };
 		78AED1332C3D951F000AD80A /* NicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewController.swift; sourceTree = "<group>"; };
 		78AED1362C3D98D1000AD80A /* NicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameView.swift; sourceTree = "<group>"; };
 		78B928682C29402C006D9942 /* KkuMulKum.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KkuMulKum.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1205,6 +1207,7 @@
 				789873372C3D1B4800435E96 /* ViewController */,
 				789873362C3D1B3900435E96 /* VIewModel */,
 				789873352C3D1B3000435E96 /* View */,
+				78AA9F1B2D6CC667001F1BCE /* Pulse.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -1934,6 +1937,7 @@
 				DDD62FFB2C5FA4FE00174B57 /* MeetingService.swift in Sources */,
 				DD43937D2C412F4500EC1799 /* CheckInviteCodeViewController.swift in Sources */,
 				DEFBEBD92C46E4C200437188 /* AddPromiseCompleteView.swift in Sources */,
+				78AA9F1C2D6CC667001F1BCE /* Pulse.swift in Sources */,
 				DEFBEBDB2C46FD5700437188 /* AddPromiseResponseModel.swift in Sources */,
 				DD4393772C412F4500EC1799 /* CreateMeetingView.swift in Sources */,
 				789873342C3D1A7B00435E96 /* LoginView.swift in Sources */,
@@ -2228,11 +2232,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KkuMulKum/KkuMulKumDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = D2DRA3F792;
+				DEVELOPMENT_TEAM = D2DRA3F792;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KkuMulKum/Resource/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "꾸물꿈";
@@ -2253,7 +2255,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = KkuMulKum.yizihn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = KkumulkumDebug;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2270,11 +2271,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KkuMulKum/KkuMulKum.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = D2DRA3F792;
+				DEVELOPMENT_TEAM = D2DRA3F792;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KkuMulKum/Resource/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "꾸물꿈";
@@ -2296,7 +2296,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = KkuMulKum.yizihn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = KkumulkumRelease1;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -30,15 +30,43 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             handleNotification(userInfo: userInfo)
         }
         
+        print("Setting up navigation pulse subscription")
+        loginViewModel.navigationPulse.subscribe(with: self) { [weak self] (owner, navigation) in
+            print("🚀 Navigation pulse received: \(navigation)")
+            guard let self = self else { return }
+            
+            DispatchQueue.main.async {
+                switch navigation {
+                case .toMain:
+                    self.showMainScreen()
+                    print("🏠 Navigating to main screen")
+                case .toOnboarding:
+                    let nicknameViewModel = NicknameViewModel()
+                    let nicknameViewController = NicknameViewController(viewModel: nicknameViewModel)
+                    let navigationController = UINavigationController(
+                        rootViewController: nicknameViewController,
+                        isBorderNeeded: false
+                    )
+                    self.animateRootViewControllerChange(to: navigationController)
+                    print("👤 Navigating to onboarding")
+
+                case .showError(let message):
+                    print("Login error: \(message)")
+                    self.showLoginScreen()
+                }
+            }
+        }
+        
         performAutoLogin()
     }
+    
     
     private func performAutoLogin() {
         print("Performing auto login")
         loginViewModel.autoLogin { [weak self] success in
             DispatchQueue.main.async {
                 if success {
-                    self?.showLoginScreen()
+                    self?.showMainScreen()
                 } else {
                     self?.showLoginScreen()
                 }
@@ -61,7 +89,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         return false
     }
     
-    private func showMainScreen() {
+     func showMainScreen() {
         let mainTabBarController = MainTabBarController()
         let navigationController = UINavigationController(
             rootViewController: mainTabBarController,

--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -38,7 +38,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         loginViewModel.autoLogin { [weak self] success in
             DispatchQueue.main.async {
                 if success {
-                    self?.showMainScreen()
+                    self?.showLoginScreen()
                 } else {
                     self?.showLoginScreen()
                 }

--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -58,21 +58,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         performAutoLogin()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-            print("🧪 Testing navigation pulse manually")
-            self.loginViewModel.navigationPulse.emit(.toMain)
-        }
     }
-    
     
     private func performAutoLogin() {
         print("Performing auto login")
         loginViewModel.autoLogin { [weak self] success in
             DispatchQueue.main.async {
-                if success {
-                    self?.showMainScreen()
-                } else {
+                if !success {
                     self?.showLoginScreen()
                 }
             }
@@ -115,7 +107,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         animateRootViewControllerChange(to: loginViewController)
     }
     
-    private func animateRootViewControllerChange(to newRootViewController: UIViewController) {
+    func animateRootViewControllerChange(to newRootViewController: UIViewController) {
         guard let window = self.window else { return }
         
         UIView.transition(with: window,

--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -58,6 +58,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         performAutoLogin()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            print("🧪 Testing navigation pulse manually")
+            self.loginViewModel.navigationPulse.emit(.toMain)
+        }
     }
     
     

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
@@ -240,6 +240,7 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
     
     private func navigateToLoginScreen() {
         let loginViewModel = LoginViewModel()
+        loginViewModel.logout()
         let loginViewController = LoginViewController(viewModel: loginViewModel)
         loginViewController.modalPresentationStyle = .fullScreen
         self.present(loginViewController, animated: true, completion: nil)

--- a/KkuMulKum/Source/Onboarding/Login/Pulse.swift
+++ b/KkuMulKum/Source/Onboarding/Login/Pulse.swift
@@ -7,18 +7,27 @@
 
 import Foundation
 
-/// 일회성 이벤트를 관리하기 위한 클래스
+/// 일회성 이벤트를 관리하기 위한 제네릭 클래스
+/// Pulse는 이벤트를 한 번만 전달하고, 이후 추가 구독자에게는 마지막 이벤트를 즉시 전달하는 메커니즘을 제공합니다.
 class Pulse<T> {
+    /// 리스너 타입 정의 (이벤트 핸들러)
     typealias Listener = (T) -> Void
     
+    /// 현재 저장된 값
     private var value: T?
+    
+    /// 등록된 리스너 목록
     private var listeners: [Listener] = []
+    
+    /// 이벤트가 이미 소비되었는지 추적하는 플래그
     private var isConsumed = false
     
-    /// 새로운 Pulse 생성
+    /// 새로운 Pulse 인스턴스 생성
     init() {}
     
-    /// 값 발신
+    /// 이벤트 값을 전달하고 모든 리스너에게 알림
+    /// - Parameter value: 전달할 이벤트 값
+    /// - Note: 이벤트는 한 번만 전달되며, 이후 추가 emit은 무시됨
     func emit(_ value: T) {
         guard !isConsumed else { return }
         
@@ -32,7 +41,8 @@ class Pulse<T> {
         listeners.removeAll()
     }
     
-    /// 리스너 등록
+    /// 리스너를 등록하고 이미 발행된 이벤트가 있다면 즉시 전달
+    /// - Parameter listener: 이벤트를 처리할 클로저
     func subscribe(_ listener: @escaping Listener) {
         if let value = value, isConsumed {
             // 이미 값이 발신되었다면 즉시 전달
@@ -43,7 +53,10 @@ class Pulse<T> {
         }
     }
     
-    /// 약한 참조로 리스너 등록
+    /// 약한 참조로 리스너를 등록하고 이미 발행된 이벤트가 있다면 즉시 전달
+    /// - Parameters:
+    ///   - object: 리스너가 속한 약한 참조 객체
+    ///   - listener: 이벤트를 처리할 클로저 (객체와 값을 받음)
     func subscribe<O: AnyObject>(with object: O, listener: @escaping (O, T) -> Void) {
         let wrappedListener: Listener = { [weak object] value in
             guard let object = object else { return }
@@ -59,7 +72,7 @@ class Pulse<T> {
         }
     }
     
-    /// 모든 리스너 제거
+    /// 모든 상태를 초기화하여 Pulse를 재사용 가능한 상태로 만듦
     func reset() {
         value = nil
         isConsumed = false

--- a/KkuMulKum/Source/Onboarding/Login/Pulse.swift
+++ b/KkuMulKum/Source/Onboarding/Login/Pulse.swift
@@ -1,0 +1,68 @@
+//
+//  Pulse.swift
+//  KkuMulKum
+//
+//  Created by 이지훈 on 2/24/25.
+//
+
+import Foundation
+
+/// 일회성 이벤트를 관리하기 위한 클래스
+class Pulse<T> {
+    typealias Listener = (T) -> Void
+    
+    private var value: T?
+    private var listeners: [Listener] = []
+    private var isConsumed = false
+    
+    /// 새로운 Pulse 생성
+    init() {}
+    
+    /// 값 발신
+    func emit(_ value: T) {
+        guard !isConsumed else { return }
+        
+        self.value = value
+        isConsumed = true
+        
+        // 모든 리스너에게 값 전달
+        listeners.forEach { $0(value) }
+        
+        // 발신 후 리스너 비우기
+        listeners.removeAll()
+    }
+    
+    /// 리스너 등록
+    func subscribe(_ listener: @escaping Listener) {
+        if let value = value, isConsumed {
+            // 이미 값이 발신되었다면 즉시 전달
+            listener(value)
+        } else {
+            // 아직 값이 없다면 리스너 등록
+            listeners.append(listener)
+        }
+    }
+    
+    /// 약한 참조로 리스너 등록
+    func subscribe<O: AnyObject>(with object: O, listener: @escaping (O, T) -> Void) {
+        let wrappedListener: Listener = { [weak object] value in
+            guard let object = object else { return }
+            listener(object, value)
+        }
+        
+        if let value = value, isConsumed {
+            // 이미 값이 발신되었다면 즉시 전달
+            wrappedListener(value)
+        } else {
+            // 아직 값이 없다면 리스너 등록
+            listeners.append(wrappedListener)
+        }
+    }
+    
+    /// 모든 리스너 제거
+    func reset() {
+        value = nil
+        isConsumed = false
+        listeners.removeAll()
+    }
+}

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -20,11 +20,30 @@ enum LoginState {
     case needOnboarding
 }
 
+enum LoginNavigation {
+    case toMain
+    case toOnboarding
+    case showError(message: String)
+}
+
 class LoginViewModel: NSObject {
-    var loginState: ObservablePattern<LoginState> = ObservablePattern(.notLogin)
-    var error: ObservablePattern<String> = ObservablePattern("")
-    var userName: ObservablePattern<String?> = ObservablePattern(nil)
+    // MARK: - Outputs
+    // 현재 상태
+    private(set) var loginState: LoginState = .notLogin {
+        didSet {
+            loginStateChanged?(loginState)
+        }
+    }
     
+    // 상태 변경 콜백
+    var loginStateChanged: ((LoginState) -> Void)?
+    
+    // Pulse 이벤트들
+    private(set) var loginResultPulse = Pulse<Result<SocialLoginResponseModel, Error>>()
+    private(set) var navigationPulse = Pulse<LoginNavigation>()
+    private(set) var errorPulse = Pulse<String>()
+    
+    // MARK: - Private properties
     private let provider: MoyaProvider<AuthTargetType>
     private var authService: AuthServiceProtocol
     private let authInterceptor: AuthInterceptor
@@ -32,6 +51,7 @@ class LoginViewModel: NSObject {
     
     private let kakaoAppKey: String
 
+    // MARK: - Initialization
     init(
         provider: MoyaProvider<AuthTargetType> = MoyaProvider<AuthTargetType>(
             plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))]
@@ -51,15 +71,21 @@ class LoginViewModel: NSObject {
         self.keychainAccessible = keychainAccessible
         super.init()
         
+        setupBindings()
         print("Initial FCM Token: \(getFCMToken())")
     }
     
-    private func getFCMToken() -> String {
-        let token = keychainAccessible.getToken("FCMToken") ?? "fcm_token_not_available"
-        print("Retrieved FCM Token: \(token)")
-        return token
+    // MARK: - Setup
+    private func setupBindings() {
+        // errorPulse 발생 시 navigationPulse(showError)도 함께 발생시키기
+        errorPulse.subscribe { [weak self] errorMessage in
+            if !errorMessage.isEmpty {
+                self?.navigationPulse.emit(.showError(message: errorMessage))
+            }
+        }
     }
     
+    // MARK: - Public Methods
     func performAppleLogin(presentationAnchor: ASPresentationAnchor) {
         print("Performing Apple Login")
         let request = ASAuthorizationAppleIDProvider().createRequest()
@@ -85,7 +111,14 @@ class LoginViewModel: NSObject {
         }
     }
     
-    private func getFCMToken(completion: @escaping (String) -> Void) {
+    // MARK: - Private Methods
+    private func getFCMToken() -> String {
+        let token = keychainAccessible.getToken("FCMToken") ?? "fcm_token_not_available"
+        print("Retrieved FCM Token: \(token)")
+        return token
+    }
+    
+    private func getFCMTokenAsync(completion: @escaping (String) -> Void) {
         Messaging.messaging().token { token, error in
             if let error = error {
                 print("Error fetching FCM registration token: \(error)")
@@ -104,18 +137,18 @@ class LoginViewModel: NSObject {
     private func handleKakaoLoginResult(oauthToken: OAuthToken?, error: Error?) {
         if let error = error {
             print("Kakao Login Error: \(error.localizedDescription)")
-            self.error.value = error.localizedDescription
+            errorPulse.emit(error.localizedDescription)
             return
         }
         
         if let token = oauthToken?.accessToken {
             print("Kakao Login Successful, access token: \(token)")
-            getFCMToken { [weak self] fcmToken in
+            getFCMTokenAsync { [weak self] fcmToken in
                 self?.loginToServer(with: .kakaoLogin(accessToken: token, fcmToken: fcmToken))
             }
         } else {
             print("Kakao Login Error: No access token")
-            self.error.value = "No access token received"
+            errorPulse.emit("No access token received")
         }
     }
     
@@ -140,12 +173,12 @@ class LoginViewModel: NSObject {
                     self?.handleLoginResponse(loginResponse)
                 } catch {
                     print("Failed to decode response: \(error)")
-                    self?.error.value = "Failed to decode response: \(error.localizedDescription)"
+                    self?.errorPulse.emit("Failed to decode response: \(error.localizedDescription)")
                 }
                 
             case .failure(let error):
                 print("Network error: \(error)")
-                self?.error.value = "Network error: \(error.localizedDescription)"
+                self?.errorPulse.emit("Network error: \(error.localizedDescription)")
             }
         }
     }
@@ -157,30 +190,34 @@ class LoginViewModel: NSObject {
                 accessToken: data.jwtTokenDTO.accessToken,
                 refreshToken: data.jwtTokenDTO.refreshToken
             )
-            userName.value = data.name
+            
+            loginResultPulse.emit(.success(data))
+            
             if data.name != nil {
                 print("Login successful, user has a name")
-                loginState.value = .login
+                loginState = .login
+                navigationPulse.emit(.toMain)
             } else {
                 print("Login successful, but user needs onboarding")
-                loginState.value = .needOnboarding
+                loginState = .needOnboarding
+                navigationPulse.emit(.toOnboarding)
             }
         } else {
             if let error = response.error {
                 print("Login failed: \(error.message)")
-                self.error.value = error.message
+                errorPulse.emit(error.message)
             } else {
                 print("Login failed: Unknown error")
-                self.error.value = "Unknown error occurred"
+                errorPulse.emit("Unknown error occurred")
             }
-            loginState.value = .notLogin
+            loginState = .notLogin
         }
     }
     
     func autoLogin(completion: @escaping (Bool) -> Void) {
         guard let refreshToken = authService.getRefreshToken() else {
             print("No refresh token found")
-            loginState.value = .notLogin
+            loginState = .notLogin
             completion(false)
             return
         }
@@ -229,8 +266,13 @@ class LoginViewModel: NSObject {
                 do {
                     let userInfoResponse = try response.map(ResponseBodyDTO<UserInfoModel>.self)
                     if userInfoResponse.success, let data = userInfoResponse.data {
-                        self?.userName.value = data.name
-                        self?.loginState.value = .login  // 이름이 있으므로 항상 .login 상태로 설정
+                        if data.name != nil {
+                            self?.loginState = .login
+                            self?.navigationPulse.emit(.toMain)
+                        } else {
+                            self?.loginState = .needOnboarding
+                            self?.navigationPulse.emit(.toOnboarding)
+                        }
                         completion(true)
                     } else {
                         self?.clearTokensAndHandleError()
@@ -251,13 +293,12 @@ class LoginViewModel: NSObject {
     
     private func clearTokensAndHandleError() {
         _ = authService.clearTokens()
-        loginState.value = .notLogin
-        error.value = "자동 로그인 실패. 다시 로그인해주세요."
+        loginState = .notLogin
+        errorPulse.emit("자동 로그인 실패. 다시 로그인해주세요.")
         print("Tokens cleared, login state set to notLogin")
     }
     
     private func saveTokens(accessToken: String, refreshToken: String) {
-
         let accessTokenSaved = authService.saveAccessToken(accessToken)
         let refreshTokenSaved = authService.saveRefreshToken(refreshToken)
         
@@ -271,33 +312,34 @@ class LoginViewModel: NSObject {
     }
 }
 
+// MARK: - ASAuthorizationControllerDelegate
 extension LoginViewModel: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-           print("Apple authorization completed")
-           guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                 let identityToken = appleIDCredential.identityToken,
-                 let tokenString = String(data: identityToken, encoding: .utf8) else {
-               print("Failed to get Apple ID Credential or identity token")
-               return
-           }
-           
-           // authorization_code 출력 추가
-           if let authorizationCode = appleIDCredential.authorizationCode,
-              let codeString = String(data: authorizationCode, encoding: .utf8) {
-               print("Authorization Code: \(codeString)")
-           } else {
-               print("Authorization Code not available")
-           }
-           
-           print("Apple Login Successful, identity token: \(tokenString)")
-           getFCMToken { [weak self] fcmToken in
-               self?.loginToServer(with: .appleLogin(identityToken: tokenString, fcmToken: fcmToken))
-           }
-       }
+        print("Apple authorization completed")
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let identityToken = appleIDCredential.identityToken,
+              let tokenString = String(data: identityToken, encoding: .utf8) else {
+            print("Failed to get Apple ID Credential or identity token")
+            return
+        }
+        
+        // authorization_code 출력 추가
+        if let authorizationCode = appleIDCredential.authorizationCode,
+           let codeString = String(data: authorizationCode, encoding: .utf8) {
+            print("Authorization Code: \(codeString)")
+        } else {
+            print("Authorization Code not available")
+        }
+        
+        print("Apple Login Successful, identity token: \(tokenString)")
+        getFCMTokenAsync { [weak self] fcmToken in
+            self?.loginToServer(with: .appleLogin(identityToken: tokenString, fcmToken: fcmToken))
+        }
+    }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         print("Apple authorization error: \(error.localizedDescription)")
-        self.error.value = error.localizedDescription
+        errorPulse.emit(error.localizedDescription)
     }
     
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -27,24 +27,24 @@ enum LoginNavigation {
 }
 
 class LoginViewModel: NSObject {
-    // MARK: - Outputs
-    // 현재 상태
+    // 현재 로그인 상태를 추적, 상태 변경 시 콜백 트리거
     private(set) var loginState: LoginState = .notLogin {
         didSet {
             loginStateChanged?(loginState)
         }
     }
     
-    // 상태 변경 콜백
     var loginStateChanged: ((LoginState) -> Void)?
     private var isLoggedOut = false
     
-    // Pulse 이벤트들
+    /// Pulse: 단일 이벤트를 한 번만 전달하는 이벤트 핸들러
+    /// - loginResultPulse: 로그인 결과
+    /// - navigationPulse: 화면 전환 이벤트
+    /// - errorPulse: 에러 메시지 전달
     private(set) var loginResultPulse = Pulse<Result<SocialLoginResponseModel, Error>>()
     private(set) var navigationPulse = Pulse<LoginNavigation>()
     private(set) var errorPulse = Pulse<String>()
     
-    // MARK: - Private properties
     private let provider: MoyaProvider<AuthTargetType>
     private var authService: AuthServiceProtocol
     private let authInterceptor: AuthInterceptor
@@ -52,7 +52,6 @@ class LoginViewModel: NSObject {
     
     private let kakaoAppKey: String
 
-    // MARK: - Initialization
     init(
         provider: MoyaProvider<AuthTargetType> = MoyaProvider<AuthTargetType>(
             plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))]
@@ -75,9 +74,8 @@ class LoginViewModel: NSObject {
         setupBindings()
     }
     
-    // MARK: - Setup
+    // 에러 발생 시 자동으로 내비게이션 pulse에 에러 메시지 전달
     private func setupBindings() {
-        // errorPulse 발생 시 navigationPulse(showError)도 함께 발생시키기
         errorPulse.subscribe { [weak self] errorMessage in
             if !errorMessage.isEmpty {
                 self?.navigationPulse.emit(.showError(message: errorMessage))
@@ -85,7 +83,6 @@ class LoginViewModel: NSObject {
         }
     }
     
-    // MARK: - Public Methods
     func performAppleLogin(presentationAnchor: ASPresentationAnchor) {
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.fullName, .email]
@@ -114,7 +111,6 @@ class LoginViewModel: NSObject {
         loginState = .notLogin
     }
     
-    // MARK: - Private Methods
     private func getFCMToken() -> String {
         return keychainAccessible.getToken("FCMToken") ?? "fcm_token_not_available"
     }
@@ -168,7 +164,6 @@ class LoginViewModel: NSObject {
     }
     
     private func handleLoginResponse(_ response: ResponseBodyDTO<SocialLoginResponseModel>) {
-        print("Handling login response")
         if response.success, let data = response.data {
             saveTokens(
                 accessToken: data.jwtTokenDTO.accessToken,
@@ -177,25 +172,19 @@ class LoginViewModel: NSObject {
             
             loginResultPulse.emit(.success(data))
             
-            // Pulse 리셋 (이전 이벤트 상태 초기화)
             navigationPulse.reset()
             
             if data.name != nil {
-                print("Login successful, user has a name")
                 loginState = .login
-                print("🚀 Emitting navigation pulse to main")
                 navigationPulse.emit(.toMain)
                 
-                // 디버깅용: 직접 화면 전환
                 DispatchQueue.main.async {
                     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
                     let sceneDelegate = windowScene?.delegate as? SceneDelegate
                     sceneDelegate?.showMainScreen()
                 }
             } else {
-                print("Login successful, but user needs onboarding")
                 loginState = .needOnboarding
-                print("🚀 Emitting navigation pulse to onboarding")
                 navigationPulse.emit(.toOnboarding)
             }
         } else {
@@ -209,7 +198,6 @@ class LoginViewModel: NSObject {
     }
     
     func autoLogin(completion: @escaping (Bool) -> Void) {
-        // 로그아웃 상태라면 자동 로그인 시도하지 않음
         if isLoggedOut {
             loginState = .notLogin
             completion(false)
@@ -301,7 +289,6 @@ class LoginViewModel: NSObject {
     }
 }
 
-// MARK: - ASAuthorizationControllerDelegate
 extension LoginViewModel: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -210,49 +210,47 @@ class LoginViewModel: NSObject {
     }
 
     
-    func autoLogin() async -> Bool {
+    func autoLogin(completion: @escaping (Bool) -> Void) {
         if isLoggedOut {
             loginState = .notLogin
-            return false
+            completion(false)
+            return
         }
         
         guard let refreshToken = authService.getRefreshToken() else {
             loginState = .notLogin
-            return false
+            completion(false)
+            return
         }
         
-        do {
-            let response: Response = try await withCheckedThrowingContinuation { continuation in
-                provider.request(.refreshToken(refreshToken: refreshToken)) { result in
-                    switch result {
-                    case .success(let response):
-                        continuation.resume(returning: response)
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
+        provider.request(.refreshToken(refreshToken: refreshToken)) { [weak self] result in
+            switch result {
+            case .success(let response):
+                do {
+                    let reissueResponse = try response.map(ResponseBodyDTO<RefreshTokenResponseModel>.self)
+                    if reissueResponse.success, let data = reissueResponse.data {
+                        let newAccessToken = data.accessToken
+                        let newRefreshToken = data.refreshToken
+                        self?.saveTokens(accessToken: newAccessToken, refreshToken: newRefreshToken)
+                        
+                        self?.fetchUserInfo { success in
+                            completion(success)
+                        }
+                    } else {
+                        self?.clearTokensAndHandleError()
+                        completion(false)
                     }
+                } catch {
+                    self?.clearTokensAndHandleError()
+                    completion(false)
                 }
+            case .failure(let error):
+                self?.clearTokensAndHandleError()
+                completion(false)
             }
-            
-            let reissueResponse = try response.map(ResponseBodyDTO<RefreshTokenResponseModel>.self)
-            if reissueResponse.success, let data = reissueResponse.data {
-                saveTokens(accessToken: data.accessToken, refreshToken: data.refreshToken)
-                
-                let userInfoSuccess: Bool = await withCheckedContinuation { continuation in
-                    self.fetchUserInfo { success in
-                        continuation.resume(returning: success)
-                    }
-                }
-                return userInfoSuccess
-            } else {
-                clearTokensAndHandleError()
-                return false
-            }
-        } catch {
-            clearTokensAndHandleError()
-            return false
         }
     }
-
+    
     private func fetchUserInfo(completion: @escaping (Bool) -> Void) {
         provider.request(.getUserInfo) { [weak self] result in
             switch result {

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -185,23 +185,35 @@ class LoginViewModel: NSObject {
     
     private func handleLoginResponse(_ response: ResponseBodyDTO<SocialLoginResponseModel>) {
         print("Handling login response")
-        if response.success, let data = response.data {
-            saveTokens(
-                accessToken: data.jwtTokenDTO.accessToken,
-                refreshToken: data.jwtTokenDTO.refreshToken
-            )
-            
-            loginResultPulse.emit(.success(data))
-            
-            if data.name != nil {
-                print("Login successful, user has a name")
-                loginState = .login
-                navigationPulse.emit(.toMain)
-            } else {
-                print("Login successful, but user needs onboarding")
-                loginState = .needOnboarding
-                navigationPulse.emit(.toOnboarding)
-            }
+          if response.success, let data = response.data {
+              saveTokens(
+                  accessToken: data.jwtTokenDTO.accessToken,
+                  refreshToken: data.jwtTokenDTO.refreshToken
+              )
+              
+              loginResultPulse.emit(.success(data))
+              
+              // Pulse 리셋 (이전 이벤트 상태 초기화)
+              navigationPulse.reset()
+              
+              if data.name != nil {
+                  print("Login successful, user has a name")
+                  loginState = .login
+                  print("🚀 Emitting navigation pulse to main")
+                  navigationPulse.emit(.toMain)
+                  
+                  // 디버깅용: 직접 화면 전환
+                  DispatchQueue.main.async {
+                      let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                      let sceneDelegate = windowScene?.delegate as? SceneDelegate
+                      sceneDelegate?.showMainScreen()
+                  }
+              } else {
+                  print("Login successful, but user needs onboarding")
+                  loginState = .needOnboarding
+                  print("🚀 Emitting navigation pulse to onboarding")
+                  navigationPulse.emit(.toOnboarding)
+              }
         } else {
             if let error = response.error {
                 print("Login failed: \(error.message)")

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -37,6 +37,7 @@ class LoginViewModel: NSObject {
     
     // 상태 변경 콜백
     var loginStateChanged: ((LoginState) -> Void)?
+    private var isLoggedOut = false
     
     // Pulse 이벤트들
     private(set) var loginResultPulse = Pulse<Result<SocialLoginResponseModel, Error>>()
@@ -72,7 +73,6 @@ class LoginViewModel: NSObject {
         super.init()
         
         setupBindings()
-        print("Initial FCM Token: \(getFCMToken())")
     }
     
     // MARK: - Setup
@@ -87,7 +87,6 @@ class LoginViewModel: NSObject {
     
     // MARK: - Public Methods
     func performAppleLogin(presentationAnchor: ASPresentationAnchor) {
-        print("Performing Apple Login")
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.fullName, .email]
         
@@ -99,32 +98,32 @@ class LoginViewModel: NSObject {
     
     func performKakaoLogin() {
         if UserApi.isKakaoTalkLoginAvailable() {
-            print("Kakao Talk is available")
             UserApi.shared.loginWithKakaoTalk { [weak self] (oauthToken, error) in
                 self?.handleKakaoLoginResult(oauthToken: oauthToken, error: error)
             }
         } else {
-            print("Kakao Talk is not available")
             UserApi.shared.loginWithKakaoAccount { [weak self] (oauthToken, error) in
                 self?.handleKakaoLoginResult(oauthToken: oauthToken, error: error)
             }
         }
     }
     
+    func logout() {
+        isLoggedOut = true
+        _ = authService.clearTokens()
+        loginState = .notLogin
+    }
+    
     // MARK: - Private Methods
     private func getFCMToken() -> String {
-        let token = keychainAccessible.getToken("FCMToken") ?? "fcm_token_not_available"
-        print("Retrieved FCM Token: \(token)")
-        return token
+        return keychainAccessible.getToken("FCMToken") ?? "fcm_token_not_available"
     }
     
     private func getFCMTokenAsync(completion: @escaping (String) -> Void) {
         Messaging.messaging().token { token, error in
             if let error = error {
-                print("Error fetching FCM registration token: \(error)")
                 completion("fcm_token_not_available")
             } else if let token = token {
-                print("Current FCM Token: \(token)")
                 UserDefaults.standard.set(token, forKey: "FCMToken")
                 UserDefaults.standard.synchronize()
                 completion(token)
@@ -136,90 +135,62 @@ class LoginViewModel: NSObject {
     
     private func handleKakaoLoginResult(oauthToken: OAuthToken?, error: Error?) {
         if let error = error {
-            print("Kakao Login Error: \(error.localizedDescription)")
             errorPulse.emit(error.localizedDescription)
             return
         }
         
         if let token = oauthToken?.accessToken {
-            print("Kakao Login Successful, access token: \(token)")
             getFCMTokenAsync { [weak self] fcmToken in
                 self?.loginToServer(with: .kakaoLogin(accessToken: token, fcmToken: fcmToken))
             }
         } else {
-            print("Kakao Login Error: No access token")
             errorPulse.emit("No access token received")
         }
     }
     
     private func loginToServer(with loginTarget: AuthTargetType) {
-        switch loginTarget {
-        case .appleLogin(_, let fcmToken), .kakaoLogin(_, let fcmToken):
-            print("Sending FCM Token to server: \(fcmToken)")
-        default:
-            break
-        }
-        
         provider.request(loginTarget) { [weak self] result in
             switch result {
             case .success(let response):
-                print("Received response from server: \(response)")
-                print("Response body: \(String(data: response.data, encoding: .utf8) ?? "")")
                 do {
                     let loginResponse = try response.map(
                         ResponseBodyDTO<SocialLoginResponseModel>.self
                     )
-                    print("Successfully mapped response: \(loginResponse)")
                     self?.handleLoginResponse(loginResponse)
                 } catch {
-                    print("Failed to decode response: \(error)")
                     self?.errorPulse.emit("Failed to decode response: \(error.localizedDescription)")
                 }
                 
             case .failure(let error):
-                print("Network error: \(error)")
                 self?.errorPulse.emit("Network error: \(error.localizedDescription)")
             }
         }
     }
     
     private func handleLoginResponse(_ response: ResponseBodyDTO<SocialLoginResponseModel>) {
-        print("Handling login response")
-          if response.success, let data = response.data {
-              saveTokens(
-                  accessToken: data.jwtTokenDTO.accessToken,
-                  refreshToken: data.jwtTokenDTO.refreshToken
-              )
-              
-              loginResultPulse.emit(.success(data))
-              
-              // Pulse 리셋 (이전 이벤트 상태 초기화)
-              navigationPulse.reset()
-              
-              if data.name != nil {
-                  print("Login successful, user has a name")
-                  loginState = .login
-                  print("🚀 Emitting navigation pulse to main")
-                  navigationPulse.emit(.toMain)
-                  
-                  // 디버깅용: 직접 화면 전환
-                  DispatchQueue.main.async {
-                      let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                      let sceneDelegate = windowScene?.delegate as? SceneDelegate
-                      sceneDelegate?.showMainScreen()
-                  }
-              } else {
-                  print("Login successful, but user needs onboarding")
-                  loginState = .needOnboarding
-                  print("🚀 Emitting navigation pulse to onboarding")
-                  navigationPulse.emit(.toOnboarding)
-              }
+        if response.success, let data = response.data {
+            saveTokens(
+                accessToken: data.jwtTokenDTO.accessToken,
+                refreshToken: data.jwtTokenDTO.refreshToken
+            )
+            
+            loginResultPulse.emit(.success(data))
+            
+            // Pulse 리셋 (이전 이벤트 상태 초기화)
+            navigationPulse.reset()
+            
+            if data.name != nil {
+                loginState = .login
+                navigationPulse.emit(.toMain)
+                
+            } else {
+                loginState = .needOnboarding
+                navigationPulse.emit(.toOnboarding)
+            }
         } else {
             if let error = response.error {
-                print("Login failed: \(error.message)")
                 errorPulse.emit(error.message)
             } else {
-                print("Login failed: Unknown error")
                 errorPulse.emit("Unknown error occurred")
             }
             loginState = .notLogin
@@ -227,14 +198,19 @@ class LoginViewModel: NSObject {
     }
     
     func autoLogin(completion: @escaping (Bool) -> Void) {
-        guard let refreshToken = authService.getRefreshToken() else {
-            print("No refresh token found")
+        // 로그아웃 상태라면 자동 로그인 시도하지 않음
+        if isLoggedOut {
             loginState = .notLogin
             completion(false)
             return
         }
         
-        print("Attempting auto login with refresh token")
+        guard let refreshToken = authService.getRefreshToken() else {
+            loginState = .notLogin
+            completion(false)
+            return
+        }
+        
         provider.request(.refreshToken(refreshToken: refreshToken)) { [weak self] result in
             switch result {
             case .success(let response):
@@ -254,17 +230,14 @@ class LoginViewModel: NSObject {
                             }
                         }
                     } else {
-                        print("Token refresh failed: \(reissueResponse.error?.message ?? "Unknown error")")
                         self?.clearTokensAndHandleError()
                         completion(false)
                     }
                 } catch {
-                    print("Token refresh failed: \(error)")
                     self?.clearTokensAndHandleError()
                     completion(false)
                 }
             case .failure(let error):
-                print("Network error during auto login: \(error)")
                 self?.clearTokensAndHandleError()
                 completion(false)
             }
@@ -291,12 +264,10 @@ class LoginViewModel: NSObject {
                         completion(false)
                     }
                 } catch {
-                    print("Failed to decode user info: \(error)")
                     self?.clearTokensAndHandleError()
                     completion(false)
                 }
             case .failure(let error):
-                print("Failed to fetch user info: \(error)")
                 self?.clearTokensAndHandleError()
                 completion(false)
             }
@@ -306,56 +277,38 @@ class LoginViewModel: NSObject {
     private func clearTokensAndHandleError() {
         _ = authService.clearTokens()
         loginState = .notLogin
-        errorPulse.emit("자동 로그인 실패. 다시 로그인해주세요.")
-        print("Tokens cleared, login state set to notLogin")
+        
+        if !isLoggedOut {
+            errorPulse.emit("자동 로그인 실패. 다시 로그인해주세요.")
+        }
+        isLoggedOut = false
     }
     
     private func saveTokens(accessToken: String, refreshToken: String) {
         let accessTokenSaved = authService.saveAccessToken(accessToken)
         let refreshTokenSaved = authService.saveRefreshToken(refreshToken)
-        
-        print("Access token saved: \(accessTokenSaved), Refresh token saved: \(refreshTokenSaved)")
-        
-        if accessTokenSaved && refreshTokenSaved {
-            print("Tokens successfully saved")
-        } else {
-            print("Failed to save tokens")
-        }
     }
 }
 
 // MARK: - ASAuthorizationControllerDelegate
 extension LoginViewModel: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        print("Apple authorization completed")
         guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
               let identityToken = appleIDCredential.identityToken,
               let tokenString = String(data: identityToken, encoding: .utf8) else {
-            print("Failed to get Apple ID Credential or identity token")
             return
         }
         
-        // authorization_code 출력 추가
-        if let authorizationCode = appleIDCredential.authorizationCode,
-           let codeString = String(data: authorizationCode, encoding: .utf8) {
-            print("Authorization Code: \(codeString)")
-        } else {
-            print("Authorization Code not available")
-        }
-        
-        print("Apple Login Successful, identity token: \(tokenString)")
         getFCMTokenAsync { [weak self] fcmToken in
             self?.loginToServer(with: .appleLogin(identityToken: tokenString, fcmToken: fcmToken))
         }
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        print("Apple authorization error: \(error.localizedDescription)")
         errorPulse.emit(error.localizedDescription)
     }
     
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        print("Providing presentation anchor for Apple Login")
         let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
         let window = windowScene?.windows.first
         return window!

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -164,45 +164,33 @@ class LoginViewModel: NSObject {
     }
     
     private func handleLoginResponse(_ response: ResponseBodyDTO<SocialLoginResponseModel>) {
-        if response.success, let data = response.data {
+        switch (response.success, response.data) {
+        case (true, let data?):
             saveTokens(
                 accessToken: data.jwtTokenDTO.accessToken,
                 refreshToken: data.jwtTokenDTO.refreshToken
             )
-            
             loginResultPulse.emit(.success(data))
             
-            // Pulse 객체를 초기화하고 새로 생성
+            // Pulse 객체 재설정
             navigationPulse = Pulse<LoginNavigation>()
             
-            if data.name != nil {
+            switch data.name {
+            case .some:
                 loginState = .login
-                print("📣📣📣 Emitting toMain navigation event")
                 navigationPulse.emit(.toMain)
-                
-                // 직접 화면 전환 (메인 화면으로)
                 DispatchQueue.main.async {
-                    print("🔄🔄🔄 Attempting direct navigation to main")
-                    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                    let sceneDelegate = windowScene?.delegate as? SceneDelegate
-                    if let sceneDelegate = sceneDelegate {
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let sceneDelegate = windowScene.delegate as? SceneDelegate {
                         sceneDelegate.showMainScreen()
-                        print("✅✅✅ Direct navigation to main successful")
-                    } else {
-                        print("❌❌❌ Failed to get sceneDelegate for direct navigation")
                     }
                 }
-            } else {
+            case .none:
                 loginState = .needOnboarding
-                print("📣📣📣 Emitting toOnboarding navigation event")
                 navigationPulse.emit(.toOnboarding)
-                
-                // 직접 화면 전환 (온보딩 화면으로)
                 DispatchQueue.main.async {
-                    print("🔄🔄🔄 Attempting direct navigation to onboarding")
-                    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                    let sceneDelegate = windowScene?.delegate as? SceneDelegate
-                    if let sceneDelegate = sceneDelegate {
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let sceneDelegate = windowScene.delegate as? SceneDelegate {
                         let nicknameViewModel = NicknameViewModel()
                         let nicknameViewController = NicknameViewController(viewModel: nicknameViewModel)
                         let navigationController = UINavigationController(
@@ -210,63 +198,61 @@ class LoginViewModel: NSObject {
                             isBorderNeeded: false
                         )
                         sceneDelegate.animateRootViewControllerChange(to: navigationController)
-                        print("✅✅✅ Direct navigation to onboarding successful")
-                    } else {
-                        print("❌❌❌ Failed to get sceneDelegate for direct navigation")
                     }
                 }
             }
-        } else {
-            if let error = response.error {
-                errorPulse.emit(error.message)
-            } else {
-                errorPulse.emit("Unknown error occurred")
-            }
+            
+        default:
+            let errorMessage = response.error?.message ?? "Unknown error occurred"
+            errorPulse.emit(errorMessage)
             loginState = .notLogin
         }
     }
+
     
-    func autoLogin(completion: @escaping (Bool) -> Void) {
+    func autoLogin() async -> Bool {
         if isLoggedOut {
             loginState = .notLogin
-            completion(false)
-            return
+            return false
         }
         
         guard let refreshToken = authService.getRefreshToken() else {
             loginState = .notLogin
-            completion(false)
-            return
+            return false
         }
         
-        provider.request(.refreshToken(refreshToken: refreshToken)) { [weak self] result in
-            switch result {
-            case .success(let response):
-                do {
-                    let reissueResponse = try response.map(ResponseBodyDTO<RefreshTokenResponseModel>.self)
-                    if reissueResponse.success, let data = reissueResponse.data {
-                        let newAccessToken = data.accessToken
-                        let newRefreshToken = data.refreshToken
-                        self?.saveTokens(accessToken: newAccessToken, refreshToken: newRefreshToken)
-                        
-                        self?.fetchUserInfo { success in
-                            completion(success)
-                        }
-                    } else {
-                        self?.clearTokensAndHandleError()
-                        completion(false)
+        do {
+            let response: Response = try await withCheckedThrowingContinuation { continuation in
+                provider.request(.refreshToken(refreshToken: refreshToken)) { result in
+                    switch result {
+                    case .success(let response):
+                        continuation.resume(returning: response)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
                     }
-                } catch {
-                    self?.clearTokensAndHandleError()
-                    completion(false)
                 }
-            case .failure(let error):
-                self?.clearTokensAndHandleError()
-                completion(false)
             }
+            
+            let reissueResponse = try response.map(ResponseBodyDTO<RefreshTokenResponseModel>.self)
+            if reissueResponse.success, let data = reissueResponse.data {
+                saveTokens(accessToken: data.accessToken, refreshToken: data.refreshToken)
+                
+                let userInfoSuccess: Bool = await withCheckedContinuation { continuation in
+                    self.fetchUserInfo { success in
+                        continuation.resume(returning: success)
+                    }
+                }
+                return userInfoSuccess
+            } else {
+                clearTokensAndHandleError()
+                return false
+            }
+        } catch {
+            clearTokensAndHandleError()
+            return false
         }
     }
-    
+
     private func fetchUserInfo(completion: @escaping (Bool) -> Void) {
         provider.request(.getUserInfo) { [weak self] result in
             switch result {

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -168,6 +168,7 @@ class LoginViewModel: NSObject {
     }
     
     private func handleLoginResponse(_ response: ResponseBodyDTO<SocialLoginResponseModel>) {
+        print("Handling login response")
         if response.success, let data = response.data {
             saveTokens(
                 accessToken: data.jwtTokenDTO.accessToken,
@@ -180,11 +181,21 @@ class LoginViewModel: NSObject {
             navigationPulse.reset()
             
             if data.name != nil {
+                print("Login successful, user has a name")
                 loginState = .login
+                print("🚀 Emitting navigation pulse to main")
                 navigationPulse.emit(.toMain)
                 
+                // 디버깅용: 직접 화면 전환
+                DispatchQueue.main.async {
+                    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                    let sceneDelegate = windowScene?.delegate as? SceneDelegate
+                    sceneDelegate?.showMainScreen()
+                }
             } else {
+                print("Login successful, but user needs onboarding")
                 loginState = .needOnboarding
+                print("🚀 Emitting navigation pulse to onboarding")
                 navigationPulse.emit(.toOnboarding)
             }
         } else {

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -172,20 +172,49 @@ class LoginViewModel: NSObject {
             
             loginResultPulse.emit(.success(data))
             
-            navigationPulse.reset()
+            // Pulse 객체를 초기화하고 새로 생성
+            navigationPulse = Pulse<LoginNavigation>()
             
             if data.name != nil {
                 loginState = .login
+                print("📣📣📣 Emitting toMain navigation event")
                 navigationPulse.emit(.toMain)
                 
+                // 직접 화면 전환 (메인 화면으로)
                 DispatchQueue.main.async {
+                    print("🔄🔄🔄 Attempting direct navigation to main")
                     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
                     let sceneDelegate = windowScene?.delegate as? SceneDelegate
-                    sceneDelegate?.showMainScreen()
+                    if let sceneDelegate = sceneDelegate {
+                        sceneDelegate.showMainScreen()
+                        print("✅✅✅ Direct navigation to main successful")
+                    } else {
+                        print("❌❌❌ Failed to get sceneDelegate for direct navigation")
+                    }
                 }
             } else {
                 loginState = .needOnboarding
+                print("📣📣📣 Emitting toOnboarding navigation event")
                 navigationPulse.emit(.toOnboarding)
+                
+                // 직접 화면 전환 (온보딩 화면으로)
+                DispatchQueue.main.async {
+                    print("🔄🔄🔄 Attempting direct navigation to onboarding")
+                    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                    let sceneDelegate = windowScene?.delegate as? SceneDelegate
+                    if let sceneDelegate = sceneDelegate {
+                        let nicknameViewModel = NicknameViewModel()
+                        let nicknameViewController = NicknameViewController(viewModel: nicknameViewModel)
+                        let navigationController = UINavigationController(
+                            rootViewController: nicknameViewController,
+                            isBorderNeeded: false
+                        )
+                        sceneDelegate.animateRootViewControllerChange(to: navigationController)
+                        print("✅✅✅ Direct navigation to onboarding successful")
+                    } else {
+                        print("❌❌❌ Failed to get sceneDelegate for direct navigation")
+                    }
+                }
             }
         } else {
             if let error = response.error {
@@ -221,12 +250,7 @@ class LoginViewModel: NSObject {
                         self?.saveTokens(accessToken: newAccessToken, refreshToken: newRefreshToken)
                         
                         self?.fetchUserInfo { success in
-                            if success {
-                                completion(true)
-                            } else {
-                                self?.clearTokensAndHandleError()
-                                completion(false)
-                            }
+                            completion(success)
                         }
                     } else {
                         self?.clearTokensAndHandleError()

--- a/KkuMulKum/Source/Onboarding/Login/ViewController/LoginViewController.swift
+++ b/KkuMulKum/Source/Onboarding/Login/ViewController/LoginViewController.swift
@@ -8,11 +8,16 @@
 import UIKit
 
 class LoginViewController: BaseViewController {
+    // MARK: - Properties
     private let loginView = LoginView()
-    private let loginViewModel: LoginViewModel
+    private let viewModel: LoginViewModel
     
+    // 중복 네비게이션 방지를 위한 플래그
+    private var isNavigating = false
+    
+    // MARK: - Initialization
     init(viewModel: LoginViewModel) {
-        self.loginViewModel = viewModel
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -20,16 +25,25 @@ class LoginViewController: BaseViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Lifecycle Methods
     override func loadView() {
         view = loginView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        bindViewModel()
+        setupBindings()
         setupAction()
+        
+        // 자동 로그인 시도
+        viewModel.autoLogin { success in
+            if !success {
+                print("Auto login failed")
+            }
+        }
     }
     
+    // MARK: - Setup Methods
     override func setupAction() {
         super.setupAction()
         
@@ -46,77 +60,100 @@ class LoginViewController: BaseViewController {
         loginView.kakaoLoginImageView.addGestureRecognizer(kakaoTapGesture)
     }
     
-    private func bindViewModel() {
-        loginViewModel.userName.bind(with: self) { owner, name in
-            Task {
-                if name != nil {
-                    await owner.navigateToMainScreen()
-                } else {
-                    await owner.navigateToOnboardingScreen()
-                }
+    private func setupBindings() {
+        // 상태 변경 콜백
+        viewModel.loginStateChanged = {state in
+            print("Login state changed: \(state)")
+            // 필요한 경우 UI 업데이트
+        }
+        
+        // 로그인 결과 Pulse 구독
+        viewModel.loginResultPulse.subscribe(with: self) { owner, result in
+            switch result {
+            case .success(let model):
+                print("Login success with user: \(model.name ?? "no name")")
+            case .failure(let error):
+                print("Login failed with error: \(error)")
             }
         }
         
-        loginViewModel.error.bind(with: self) { owner, error in
-            Task {
-                if !error.isEmpty {
-                    print("Login Error: \(error)")
-                    await owner.showErrorAlert(message: error)
-                }
+        // 네비게이션 Pulse 구독
+        viewModel.navigationPulse.subscribe(with: self) { owner, navigation in
+            // 중복 네비게이션 방지
+            guard !owner.isNavigating else { return }
+            owner.isNavigating = true
+            
+            switch navigation {
+            case .toMain:
+                owner.navigateToMainScreen()
+            case .toOnboarding:
+                owner.navigateToOnboardingScreen()
+            case .showError(let message):
+                owner.showErrorAlert(message: message)
             }
         }
     }
     
+    // MARK: - Action Methods
     @objc private func appleLoginTapped() {
-        Task {
-            loginViewModel.performAppleLogin(presentationAnchor: view.window!)
-        }
+        guard let window = view.window else { return }
+        viewModel.performAppleLogin(presentationAnchor: window)
     }
     
     @objc private func kakaoLoginTapped() {
-        Task {
-            loginViewModel.performKakaoLogin()
+        viewModel.performKakaoLogin()
+    }
+    
+    // MARK: - Navigation Methods
+    private func navigateToMainScreen() {
+        let mainTabBarController = MainTabBarController()
+        let navigationController = UINavigationController(
+            rootViewController: mainTabBarController,
+            isBorderNeeded: false
+        )
+        navigationController.isNavigationBarHidden = true
+        navigationController.modalPresentationStyle = .fullScreen
+        navigationController.modalTransitionStyle = .crossDissolve
+        
+        // 네비게이션 완료 후 플래그 초기화
+        present(navigationController, animated: true) { [weak self] in
+            self?.isNavigating = false
         }
     }
     
-    private func navigateToMainScreen() async {
-        await MainActor.run {
-            let mainTabBarController = MainTabBarController()
+    private func navigateToOnboardingScreen() {
+        let nicknameViewController = NicknameViewController()
+        
+        if let navigationController = self.navigationController {
+            // 네비게이션 컨트롤러가 있는 경우 push
+            navigationController.pushViewController(nicknameViewController, animated: true)
+            
+            // 애니메이션 완료 후 플래그 초기화
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                self?.isNavigating = false
+            }
+        } else {
+            // 네비게이션 컨트롤러가 없는 경우 새로 생성
             let navigationController = UINavigationController(
-                rootViewController: mainTabBarController,
+                rootViewController: nicknameViewController,
                 isBorderNeeded: false
             )
-            navigationController.isNavigationBarHidden = true
             navigationController.modalPresentationStyle = .fullScreen
             navigationController.modalTransitionStyle = .crossDissolve
-            self.present(navigationController, animated: true, completion: nil)
-        }
-    }
-    
-    private func navigateToOnboardingScreen() async {
-        await MainActor.run {
             
-            let nicknameViewController = NicknameViewController()
-            if let navigationController = self.navigationController {
-                navigationController.pushViewController(nicknameViewController, animated: true)
-            } else {
-                let navigationController = UINavigationController(
-                    rootViewController: nicknameViewController,
-                    isBorderNeeded: false
-                )
-                navigationController.modalPresentationStyle = .fullScreen
-                navigationController.modalTransitionStyle = .crossDissolve
-                self.present(navigationController, animated: true, completion: nil)
+            // 네비게이션 완료 후 플래그 초기화
+            present(navigationController, animated: true) { [weak self] in
+                self?.isNavigating = false
             }
         }
     }
     
-    private func showErrorAlert(message: String) async {
-        await MainActor.run {
-            print("Showing error alert with message: \(message)")
-            let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-        }
+    private func showErrorAlert(message: String) {
+        print("Showing error alert with message: \(message)")
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default) { [weak self] _ in
+            self?.isNavigating = false
+        })
+        present(alert, animated: true)
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #408 

## 📄 작업 내용
- ReactorKit의 Pulse 구현
- 로그인 중복 호출 문제 해결

## 기능 내용이기에 GIF는 생략합니다

## 💻 About Pulse

# 문제발생

현재 로그인 기준으로, 앱 **첫 설치후 첫 로그인 / 회원가입 버튼을 클릭시** 네트워크 response가 약간 딜레이되고있는 상황입니다. 현재 이 지연중 로그인 버튼을 여러번 누르게 되었을때 동일한 API가 두번 사용되는 문제가 있었습니다. (Error Alert도 중복으로 날아오는 문제 발생)

현재 옵저버블 객체로 사용하고있는 해당 문제 대신,  Rxswift를 사용하여 해당 문제를 해결하려 했습니다.

## RxSwift 적용 고민

초기에는 RxSwift를 활용하여 이 문제를 해결하고자 했습니다만

1. `PublishRelay`는 지속적인 이벤트 스트림에 최적화되어 있어, 로그인과 같은 단일 이벤트 처리에는 적합하지 않았습니다.
2. `BehaviorSubject`나 `ReplaySubject`는 이벤트 값을 캐싱할 수 있지만, 완료 후에는 새로운 구독이 불가능하다는 제약이 있었습니다. 특히 로그인 후 화면 전환 과정에서 새로운 컨트롤러가 이전 이벤트 결과에 접근해야 하는 상황에서 문제가 되었습니다.
3. 로그인 컨텍스트(카카오 로그인 vs 애플 로그인)를 유지하기 위해서는 복잡한 타입 정의와 연산자 체인이 필요했습니다.
4. 기존 프로젝트의 콜백 패턴을 크게 변경하고 싶지는 않았습니다.

## Pulse 도입

이러한 제약을 해결하기 위해 ReactorKit의 Pulse 개념에서 영감을 얻은 커스텀 코드를 사용하게 되었습니다.

(공부하는 김에 도입한것도 물론 있습니다,,ㅎㅎ)

1. 이벤트가 한 번만 발생하도록 보장하는 `isConsumed` 플래그를 통해 중복 API 호출 문제를 효과적으로 해결했습니다.
2. 이벤트 발생 후에도 값을 유지하여 나중에 등록된 구독자에게 전달할 수 있어, 화면 전환 시 이전 결과에 접근이 가능했습니다.
3. 복잡한 타입 정의 없이도 이벤트 컨텍스트 정보를 쉽게 포함할 수 있었습니다.
4. 기존의 콜백 패턴과 자연스럽게 통합되어 코드 변경을 최소화할 수 있었습니다.

<details>
   <summary>
    <h1>
      <a href="https://github.com/ReactorKit/ReactorKit/blob/master/Sources/ReactorKit/Pulse.swift" style="text-decoration: none; color: inherit;">
        Pulse란?
      </a>
    </h1>
  </summary>

지속적인 상태로 유지되어야 하는 데이터와 단 한 번만 발생해야 하는 이벤트를 구분하는 방법을 위해 사용됩니다. `Pulse`는 **일회성 이벤트를 처리하기 위해 설계된 메커니즘입니다**. 

ReactorKit 프레임워크에서는 `@Pulse` 프로퍼티 래퍼로 구현되어 있으며, 이는 특정 상태 값이 변경될 때만 옵저버가 트리거되도록 합니다.

ReactorKit과 같은 구조화된 아키텍처에서는 일반적으로 상태(state)를 단일 진실의 원천(single source of truth)으로 관리하게 되는데, **모든 UI 관련 이벤트가 지속적인 상태로 취급되어야 하는 것은 아닙니다**.
**알림, 경고, 네비게이션 트리거, 오류 메시지와 같은 이벤트는 한 번만 발생해야 하며, 뷰가 다시 로드되거나 애플리케이션 상태가 변경될 때 반복되어서는 안 됩니다.**

Pulse는 이러한 일회성 이벤트를 지속적인 상태 관리 시스템과 별도로 발행하고 소비하는 인스턴스를 제공해서 문제를 해결해버립니다람쥐

## Pulse의 작동 방식

Pulse의 가장 기본적인 특징은 **한 번만 소비(consume once)** 동작입니다. Pulse를 통해 이벤트가 발행되면, 이 이벤트는 리스너에게 전달되지만 단 한 번만 발생합니다. 이는 `isConsumed` 플래그를 통해 구현되며, 이벤트가 한 번 발생한 후에는 추가 이벤트 발행이 차단됩니다.

또 다른 중요한 특징은 이벤트 캐싱입니다. Pulse는 발행된 이벤트 값을 저장하고, 나중에 리스너가 등록되면 이미 소비된 이벤트라도 해당 값을 전달합니다. 이는 화면 전환 후에도 이전 이벤트 결과에 접근해야 하는 경우에 특히 유용합니다.

## ReactorKit에서의 @Pulse

(모두가 Rx를 알고있으니,,,자세한 코드 설명은 빼겟습니다)

ReactorKit 프레임워크에서 `@Pulse`는 프로퍼티 래퍼로 구현되어 있으며, 특정 상태 값이 변경될 때만 옵저버가 트리거되도록 합니다:

```swift
struct State {
    var value: Int
    var isLoading: Bool
    @Pulse var alertMessage: String?
}

```

일반 상태 변수와 달리, `@Pulse`로 표시된 변수는 이 값이 변경될 때만 구독자에게 알림을 보냅니다. 이는 불필요한 UI 업데이트를 방지하고, 일회성 이벤트 처리를 단순화합니다.

```swift
reactor.pulse(\.$alertMessage)
  .compactMap { $0 }
  .subscribe(onNext: { [weak self] message in
    // 알림 표시 로직
  })
  .disposed(by: disposeBag)

```

## 실사용하는 경우

Pulse는 다음과 같은 상황에서 특히 유용합니다:

1. **네비게이션 이벤트**: 특정 조건이 충족될 때 한 번만 다른 화면으로 이동
2. **알림 메시지**: 사용자에게 오류나 성공 메시지를 중복 없이 한 번만 표시
3. **애니메이션 트리거**: 특정 상태 변화에 의해 애니메이션이 한 번만 실행되도록 함
4. **폼 검증 결과**: 폼 제출 결과를 한 번만 표시
6. **권한 요청**: 앱에서 특정 권한을 요청한 후 결과를 사용자에게 알림

## RxSwift vs Pulse

RxSwift와Pulse의 일회성 이벤트 처리에는 몇 가지 한계가 있습니다:

1. **PublishRelay/Subject**: 이들은 지속적인 데이터 스트림을 처리하는 데 최적화되어 있어, 일회성 이벤트 처리와는 다른 다릅니다.
2. **BehaviorSubject/ReplaySubject**: 값을 캐싱할 수 있지만, 완료된 후에는 새로운 구독이 불가능한 제약이 있습니다.

반면 Pulse는 일회성 이벤트 처리를 위해 특별히 설계되었으며, 이벤트가 한 번만 발생하도록 보장하면서도 필요한 경우 값을 캐싱하고 전달할 수 있습니다.

## 결론

Pulse는 일회성 이벤트와 지속적인 상태를 명확하게 구분하여 관리할 수 있는 강력한 도구이다!
</details> 

## 코드설명

현재 리뷰하시면서 이해하기 편하도록 기본 주석과 describtion을 많이 작성해두었는데 이부분은 코드리뷰 이후 삭제하도록 하겟습니다.

## 1. Pulse 클래스

```swift
class Pulse<T> {
    typealias Listener = (T) -> Void

    private var value: T?
    private var listeners: [Listener] = []
    private var isConsumed = false

    // 이벤트 발행
    func emit(_ value: T) {
        guard !isConsumed else { return }

        self.value = value
        isConsumed = true

        listeners.forEach { $0(value) }
        listeners.removeAll()
    }

    // 구독 등록
    func subscribe(_ listener: @escaping Listener) {
        if let value = value, isConsumed {
            listener(value)
        } else {
            listeners.append(listener)
        }
    }

    // 약한 참조로 구독 등록 (DisPoseBag 사용 X)
    func subscribe<O: AnyObject>(with object: O, listener: @escaping (O, T) -> Void) {
        //....
    }

    // 상태 초기화
    func reset() {
        value = nil
        isConsumed = false
        listeners.removeAll()
    }
}

```

1. **일회성 이벤트 보장**: `isConsumed` 플래그를 통해 이벤트가 단 한 번만 발생하도록 보장합니다.
2. **값 캐싱**: 발생한 이벤트의 값을 저장하고, 새로운 구독자에게 자동으로 전달합니다.

## 2. LoginViewModel에서의 Pulse 활용

`LoginViewModel.swift`에서는 세 가지 Pulse 인스턴스를 사용하여 각기 다른 유형의 일회성 이벤트를 처리합니다

```swift
private(set) var loginResultPulse = Pulse<Result<SocialLoginResponseModel, Error>>()
private(set) var navigationPulse = Pulse<LoginNavigation>()
private(set) var errorPulse = Pulse<String>()
각 Pulse의 역할:
```

- **loginResultPulse**: 로그인 API 호출 결과를 전달합니다. 성공 또는 실패 정보를 담고 있습니다.
- **navigationPulse**: 로그인 결과에 따라 다음 화면으로의 네비게이션 이벤트를 전달합니다 (메인 화면, 온보딩 화면, 오류 알림).
- **errorPulse**: 오류 메시지를 전달합니다.

이 인스턴스들을 통해

```swift
// 에러 발생 시 자동으로 내비게이션 pulse에 에러 메시지 전달
private func setupBindings() {
    errorPulse.subscribe { [weak self] errorMessage in
        if !errorMessage.isEmpty {
            self?.navigationPulse.emit(.showError(message: errorMessage))
        }
    }
}
```

 `errorPulse`에서 에러 메시지가 발생하면 자동으로 `navigationPulse`를 통해 오류 알림 화면으로 네비게이션하도록 합니다. 즉, 두 이벤트 스트림을 연결해줍니다.

```swift
private func handleLoginResponse(_ response: ResponseBodyDTO<SocialLoginResponseModel>) {
    switch (response.success, response.data) {
    case (true, let data?):
        saveTokens(
            accessToken: data.jwtTokenDTO.accessToken,
            refreshToken: data.jwtTokenDTO.refreshToken
        )
        loginResultPulse.emit(.success(data))

        // Pulse 객체 재설정
        navigationPulse = Pulse<LoginNavigation>()

        switch data.name {
        case .some:
            loginState = .login
            navigationPulse.emit(.toMain)
            // 메인 화면으로 네비게이션
        case .none:
            loginState = .needOnboarding
            navigationPulse.emit(.toOnboarding)
            // 온보딩 화면으로 네비게이션
        }

    default:
        let errorMessage = response.error?.message ?? "Unknown error occurred"
        errorPulse.emit(errorMessage)
        loginState = .notLogin
    }
}

```

로그인 성공 후 `navigationPulse = Pulse<LoginNavigation>()`로 Pulse 객체를 재설정하는 부분입니다. 이는 이전의 네비게이션 이벤트를 초기화하고 새로운 이벤트만 처리하도록 보장합니다.

## 3. LoginViewController에서 Pulse 구독

`LoginViewController.swift`에서는 ViewModel의 Pulse 이벤트를 구독하여 UI 업데이트와 화면 전환을 처리합니다

```swift
private func setupBindings() {
    // 상태 변경 콜백
    viewModel.loginStateChanged = {state in
        print("Login state changed: \(state)")
    }

    // 로그인 결과 Pulse 구독
    viewModel.loginResultPulse.subscribe(with: self) { owner, result in
        switch result {
        case .success(let model):
            print("Login success with user: \(model.name ?? "no name")")
        case .failure(let error):
            print("Login failed with error: \(error)")
        }
    }

    // 네비게이션 Pulse 구독
    viewModel.navigationPulse.subscribe(with: self) { owner, navigation in
        // 중복 네비게이션 방지
        guard !owner.isNavigating else { return }
        owner.isNavigating = true

        switch navigation {
        case .toMain:
            owner.navigateToMainScreen()
        case .toOnboarding:
            owner.navigateToOnboardingScreen()
        case .showError(let message):
            owner.showErrorAlert(message: message)
        }
    }
}

```

- 네비게이션 이벤트 처리 시 `isNavigating` 플래그를 사용하여 중복 네비게이션을 방지합니다.
- 이벤트 유형에 따라 적절한 화면 전환 메서드를 호출합니다.

## 4. SceneDelegate에서의 Pulse 활용

`SceneDelegate.swift`에서도 LoginViewModel의 navigationPulse를 구독하여 화면 전환을 합니다.

```swift
func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
    //...

    print("Setting up navigation pulse subscription")
    loginViewModel.navigationPulse.subscribe(with: self) { [weak self] (owner, navigation) in
        print("🚀 Navigation pulse received: \(navigation)")
        guard let self = self else { return }

        DispatchQueue.main.async {
            switch navigation {
            case .toMain:
                self.showMainScreen()
                print("🏠 Navigating to main screen")
            case .toOnboarding:
                let nicknameViewModel = NicknameViewModel()
                let nicknameViewController = NicknameViewController(viewModel: nicknameViewModel)
                let navigationController = UINavigationController(
                    rootViewController: nicknameViewController,
                    isBorderNeeded: false
                )
                self.animateRootViewControllerChange(to: navigationController)
                print("👤 Navigating to onboarding")

            case .showError(let message):
                print("Login error: \(message)")
                self.showLoginScreen()
            }
        }
    }

    performAutoLogin()
}

```

자동로그인 코드를 여기서 실행합니다.

## 5. 버튼 중복 클릭 문제 해결

가장 큰 문제였던 중복 로그인호출 문제를 해결한 과정입니다.

1. **LoginViewModel에서**:
이 코드 자체에는 중복 클릭 방지 로직이 없지만, Pulse의 `isConsumed` 플래그를 통해 동일한 API 호출이 여러 번 발생하더라도 네비게이션 이벤트는 한 번만 처리됩니다.
    
    ```swift
    func performKakaoLogin() {
        if UserApi.isKakaoTalkLoginAvailable() {
            UserApi.shared.loginWithKakaoTalk { [weak self] (oauthToken, error) in
                self?.handleKakaoLoginResult(oauthToken: oauthToken, error: error)
            }
        } else {
            UserApi.shared.loginWithKakaoAccount { [weak self] (oauthToken, error) in
                self?.handleKakaoLoginResult(oauthToken: oauthToken, error: error)
            }
        }
    }
    
    ```
    
2. **LoginViewController에서**:

여기서는 `isNavigating` 플래그를 추가로 사용하여 UI 레벨에서도 중복 네비게이션을 방지합니다.
```swift
    viewModel.navigationPulse.subscribe(with: self) { owner, navigation in
        // 중복 네비게이션 방지
        guard !owner.isNavigating else { return }
        owner.isNavigating = true
    
        // 네비게이션 처리...
    }
```

## 참고한곳
https://github.com/ReactorKit/ReactorKit/blob/master/Sources/ReactorKit/Pulse.swift

## 👀 기타 더 이야기해볼 점
ReactorKit의 정확한 이해와 Pulse의 정확한 이해가 저도 많이 부족합니다만 열심히 해보았습니다 매서운 코드리뷰 부탁드리고 이해가 안가거나 질문 있으시다면 남겨주세요 제가 모르는 부분일수 있는데 같이 공부해 보아요!