### PR TITLE
[Feat/#417] UIkit -> SwiftUI 마이그레이션

### DIFF
--- a/KkuMulKum/Network/DTO/Model/Users/LoginUserResponseModel.swift
+++ b/KkuMulKum/Network/DTO/Model/Users/LoginUserResponseModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 현재 로그인된 유저의 정보를 조회 (Response)
-struct LoginUserModel: ResponseModelType {
+struct LoginUserModel: ResponseModelType, Equatable {
     let userID: Int
     let name: String?
     let level: Int

--- a/KkuMulKum/Resource/Extension/Font+SwiftUI.swift
+++ b/KkuMulKum/Resource/Extension/Font+SwiftUI.swift
@@ -1,0 +1,39 @@
+//
+//  Font+SwiftUI.swift
+//  KkuMulKum
+//
+//  Created by SwiftUI Migration on 2025/01/08.
+//
+
+import SwiftUI
+
+extension Font {
+    static func pretendard(_ style: UIFont.Pretendard) -> Font {
+        return Font.custom(style.weight, size: style.size)
+    }
+    
+    // Convenience methods for common styles
+    static var pretendardTitle00: Font { pretendard(.title00) }
+    static var pretendardTitle01: Font { pretendard(.title01) }
+    static var pretendardTitle02: Font { pretendard(.title02) }
+    static var pretendardHead01: Font { pretendard(.head01) }
+    static var pretendardHead02: Font { pretendard(.head02) }
+    static var pretendardBody01: Font { pretendard(.body01) }
+    static var pretendardBody02: Font { pretendard(.body02) }
+    static var pretendardBody03: Font { pretendard(.body03) }
+    static var pretendardBody04: Font { pretendard(.body04) }
+    static var pretendardBody05: Font { pretendard(.body05) }
+    static var pretendardBody06: Font { pretendard(.body06) }
+    static var pretendardCaption01: Font { pretendard(.caption01) }
+    static var pretendardCaption02: Font { pretendard(.caption02) }
+    static var pretendardLabel00: Font { pretendard(.label00) }
+    static var pretendardLabel01: Font { pretendard(.label01) }
+    static var pretendardLabel02: Font { pretendard(.label02) }
+}
+
+// SwiftUI Color extension for UIKit colors
+extension Color {
+    init(uiColor: UIColor) {
+        self.init(uiColor)
+    }
+}

--- a/KkuMulKum/Source/MyPage/View/MyPageContentSwiftUIView.swift
+++ b/KkuMulKum/Source/MyPage/View/MyPageContentSwiftUIView.swift
@@ -1,0 +1,146 @@
+//
+//  MyPageContentSwiftUIView.swift
+//  KkuMulKum
+//
+//  Created by SwiftUI Migration on 2025/01/08.
+//
+
+import SwiftUI
+import Combine
+import RxSwift
+
+struct MyPageContentSwiftUIView: View {
+    @StateObject private var viewModelWrapper: MyPageViewModelWrapper
+    @State private var profileImage: UIImage? = UIImage.imgProfile
+    
+    init(viewModel: MyPageViewModel) {
+        _viewModelWrapper = StateObject(wrappedValue: MyPageViewModelWrapper(viewModel: viewModel))
+    }
+    
+    var body: some View {
+        ZStack {
+            Color(UIColor.green1)
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                // Profile Stack - 높이 120으로 고정
+                VStack(spacing: 12) {
+                    // Profile Image with Edit Button
+                    ZStack(alignment: .bottomTrailing) {
+                        if let image = profileImage {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: Screen.height(82), height: Screen.height(82))
+                                .clipShape(Circle())
+                        } else {
+                            Image(uiImage: UIImage.imgProfile)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: Screen.height(82), height: Screen.height(82))
+                                .clipShape(Circle())
+                        }
+                        
+                        Button(action: {
+                            viewModelWrapper.viewModel.editButtonTapped.accept(())
+                        }) {
+                            Image(uiImage: UIImage.imgEdit)
+                                .resizable()
+                                .frame(width: Screen.width(24), height: Screen.width(24))
+                                .background(Color.white)
+                                .clipShape(Circle())
+                        }
+                    }
+                    
+                    // Name Label
+                    Text(getUserName())
+                        .font(.pretendard(.body01))
+                        .foregroundColor(Color(UIColor.gray8))
+                }
+                .frame(height: Screen.height(120))
+                .padding(.top, 24)
+                
+                // Level Badge - profileStackView 아래 12pt
+                ZStack {
+                    RoundedRectangle(cornerRadius: Screen.height(36) / 2)
+                        .fill(Color(UIColor.maincolor))
+                        .frame(height: Screen.height(36))
+                    
+                    HStack(spacing: 4) {
+                        Text("Lv. \(viewModelWrapper.userInfo?.level ?? 1)")
+                            .font(.pretendard(.body05))
+                            .foregroundColor(Color(UIColor.lightGreen))
+                        
+                        Text(getLevelText())
+                            .font(.pretendard(.body05))
+                            .foregroundColor(.white)
+                    }
+                }
+                .frame(height: Screen.height(36))
+                .padding(.horizontal, 83)
+                .padding(.top, 12)
+                
+                // Separator - levelView 아래 35pt
+                Rectangle()
+                    .fill(Color(UIColor.green2))
+                    .frame(height: Screen.height(6))
+                    .padding(.top, 35)
+                
+                Spacer(minLength: 25)
+            }
+        }
+        .onAppear {
+            if let urlString = viewModelWrapper.userInfo?.profileImageURL,
+               let url = URL(string: urlString) {
+                loadImage(from: url)
+            }
+        }
+        .onChange(of: viewModelWrapper.userInfo) { newValue in
+            if let urlString = newValue?.profileImageURL,
+               let url = URL(string: urlString) {
+                loadImage(from: url)
+            }
+        }
+    }
+    
+    private func getUserName() -> String {
+        if let name = viewModelWrapper.userInfo?.name {
+            return "\(name) 님"
+        }
+        return "꾸물리안 님"
+    }
+    
+    private func getLevelText() -> String {
+        viewModelWrapper.viewModel.getLevelText(for: viewModelWrapper.userInfo?.level ?? 1)
+    }
+    
+    private func loadImage(from url: URL) {
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            if let data = data, let image = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    self.profileImage = image
+                }
+            }
+        }.resume()
+    }
+}
+
+// Wrapper class to bridge RxSwift and SwiftUI
+class MyPageViewModelWrapper: ObservableObject {
+    @Published var userInfo: LoginUserModel?
+    let viewModel: MyPageViewModel
+    private let disposeBag = DisposeBag()
+    
+    init(viewModel: MyPageViewModel) {
+        self.viewModel = viewModel
+        
+        // Subscribe to RxSwift BehaviorRelay and update @Published property
+        viewModel.userInfo
+            .subscribe(onNext: { [weak self] info in
+                DispatchQueue.main.async {
+                    self?.userInfo = info
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/KkuMulKum/Source/MyPage/View/MyPageEtcSettingSwiftUIView.swift
+++ b/KkuMulKum/Source/MyPage/View/MyPageEtcSettingSwiftUIView.swift
@@ -1,0 +1,107 @@
+//
+//  MyPageEtcSettingSwiftUIView.swift
+//  KkuMulKum
+//
+//  Created by SwiftUI Migration on 2025/01/08.
+//
+
+import SwiftUI
+import RxSwift
+
+struct MyPageEtcSettingSwiftUIView: View {
+    let viewModel: MyPageViewModel
+    @State private var showLogoutAlert = false
+    @State private var showUnsubscribeAlert = false
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 12) {
+                // 버전정보
+                SettingRow(
+                    title: "버전정보",
+                    subtitle: "1.0.2",
+                    action: {
+                        print("버전정보 탭됨")
+                    }
+                )
+                .frame(height: (geometry.size.height - 44 - 48) / 5) // padding 44, spacing 48
+                
+                // 이용약관
+                SettingRow(
+                    title: "이용약관",
+                    action: {
+                        NotificationCenter.default.post(
+                            name: Notification.Name("ShowTerms"),
+                            object: nil
+                        )
+                    }
+                )
+                .frame(height: (geometry.size.height - 44 - 48) / 5)
+                
+                // 문의하기
+                SettingRow(
+                    title: "문의하기",
+                    action: {
+                        NotificationCenter.default.post(
+                            name: Notification.Name("ShowAsk"),
+                            object: nil
+                        )
+                    }
+                )
+                .frame(height: (geometry.size.height - 44 - 48) / 5)
+                
+                // 로그아웃
+                SettingRow(
+                    title: "로그아웃",
+                    action: {
+                        viewModel.logoutButtonTapped.accept(())
+                    }
+                )
+                .frame(height: (geometry.size.height - 44 - 48) / 5)
+                
+                // 탈퇴하기
+                SettingRow(
+                    title: "탈퇴하기",
+                    action: {
+                        viewModel.unsubscribeButtonTapped.accept(())
+                    }
+                )
+                .frame(height: (geometry.size.height - 44 - 48) / 5)
+            }
+            .padding(22)
+            .background(Color.white)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(UIColor.gray2), lineWidth: 1)
+            )
+            .cornerRadius(8)
+        }
+    }
+}
+
+struct SettingRow: View {
+    let title: String
+    var subtitle: String? = nil
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .center) {
+                Text(title)
+                    .font(.pretendard(.body03))
+                    .foregroundColor(Color(UIColor.gray7))
+                
+                Spacer()
+                
+                if let subtitle = subtitle {
+                    Text(subtitle)
+                        .font(.pretendard(.body03))
+                        .foregroundColor(Color(UIColor.gray8))
+                }
+            }
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}

--- a/KkuMulKum/Source/MyPage/View/MyPageSwiftUIView.swift
+++ b/KkuMulKum/Source/MyPage/View/MyPageSwiftUIView.swift
@@ -1,0 +1,41 @@
+//
+//  MyPageSwiftUIView.swift
+//  KkuMulKum
+//
+//  Created by SwiftUI Migration on 2025/01/08.
+//
+
+import SwiftUI
+import RxSwift
+
+struct MyPageSwiftUIView: View {
+    @StateObject private var viewModelWrapper: MyPageViewModelWrapper
+    
+    init(viewModel: MyPageViewModel) {
+        _viewModelWrapper = StateObject(wrappedValue: MyPageViewModelWrapper(viewModel: viewModel))
+    }
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Color(UIColor.green1)
+                    .ignoresSafeArea()
+                
+                VStack(spacing: 0) {
+                    MyPageContentSwiftUIView(viewModel: viewModelWrapper.viewModel)
+                        .frame(height: 24 + Screen.height(120) + 12 + Screen.height(36) + 35 + Screen.height(6) + 25)
+                    
+                    let contentHeight = 24 + Screen.height(120) + 12 + Screen.height(36) + 35 + Screen.height(6) + 25
+                    let etcHeight = geometry.size.height - contentHeight - 12 - 127
+                    
+                    MyPageEtcSettingSwiftUIView(viewModel: viewModelWrapper.viewModel)
+                        .frame(height: max(0, etcHeight))
+                        .padding(.horizontal, 20)
+                        .padding(.top, 12)
+                    
+                    Spacer(minLength: 127)
+                }
+            }
+        }
+    }
+}

--- a/KkuMulKum/Source/MyPage/View/MyPageView.swift
+++ b/KkuMulKum/Source/MyPage/View/MyPageView.swift
@@ -6,19 +6,42 @@
 //
 
 import UIKit
+import SwiftUI
 
 import SnapKit
 import Then
 
 class MyPageView: BaseView {
     private let topBackgroundView = UIView(backgroundColor: .white)
-    let contentView = MyPageContentView()
+    var contentHostingController: UIHostingController<MyPageContentSwiftUIView>?
+    let contentContainerView = UIView()
     let etcSettingView = MyPageEtcSettingView()
     
     override func setupView() {
         backgroundColor = .green1
         
-        addSubviews(topBackgroundView, contentView, etcSettingView)
+        contentContainerView.backgroundColor = .clear
+        addSubviews(topBackgroundView, contentContainerView, etcSettingView)
+    }
+    
+    func setupSwiftUIContent(with viewModel: MyPageViewModel) {
+        let swiftUIView = MyPageContentSwiftUIView(viewModel: viewModel)
+        contentHostingController = UIHostingController(rootView: swiftUIView)
+        
+        if let hostingController = contentHostingController {
+            hostingController.view.backgroundColor = .clear
+            hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+            
+            contentContainerView.addSubview(hostingController.view)
+            
+            // SwiftUI 뷰에 오토레이아웃 제약 추가
+            NSLayoutConstraint.activate([
+                hostingController.view.topAnchor.constraint(equalTo: contentContainerView.topAnchor),
+                hostingController.view.leadingAnchor.constraint(equalTo: contentContainerView.leadingAnchor),
+                hostingController.view.trailingAnchor.constraint(equalTo: contentContainerView.trailingAnchor),
+                hostingController.view.bottomAnchor.constraint(equalTo: contentContainerView.bottomAnchor)
+            ])
+        }
     }
     
     override func setupAutoLayout() {
@@ -30,13 +53,16 @@ class MyPageView: BaseView {
             $0.bottom.equalTo(safeArea.snp.top)
         }
         
-        contentView.snp.makeConstraints {
+        contentContainerView.snp.makeConstraints {
             $0.top.equalTo(safeArea)
             $0.horizontalEdges.equalToSuperview()
+            // 기존 MyPageContentView의 높이와 동일하게 설정
+            // top padding(24) + profileStackView(120) + spacing(12) + levelView(36) + spacing(35) + separator(6) + bottom(25)
+            $0.height.equalTo(24 + Screen.height(120) + 12 + Screen.height(36) + 35 + Screen.height(6) + 25)
         }
         
         etcSettingView.snp.makeConstraints {
-            $0.top.equalTo(contentView.snp.bottom).offset(12)
+            $0.top.equalTo(contentContainerView.snp.bottom).offset(12)
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.bottom.equalTo(safeArea).offset(-127)
         }

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 import RxSwift
 import RxCocoa
@@ -33,6 +34,14 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .green1
+        
+        // Setup SwiftUI content view
+        rootView.setupSwiftUIContent(with: viewModel)
+        if let hostingController = rootView.contentHostingController {
+            addChild(hostingController)
+            hostingController.didMove(toParent: self)
+        }
+        
         Amplitude.instance().logEvent("test_event_from_app")
             print("📤 테스트 이벤트 전송 완료")
         bindViewModel()
@@ -45,9 +54,10 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
     
     private func bindViewModel() {
         // Inputs
-        rootView.contentView.editButton.rx.tap
-            .bind(to: viewModel.editButtonTapped)
-            .disposed(by: disposeBag)
+        // Edit button is now handled by SwiftUI view directly
+        // rootView.contentView.editButton.rx.tap
+        //     .bind(to: viewModel.editButtonTapped)
+        //     .disposed(by: disposeBag)
         
         bindRowTapGesture(for: rootView.etcSettingView.logoutRow)
             .bind(to: viewModel.logoutButtonTapped)
@@ -122,85 +132,31 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
             })
             .disposed(by: disposeBag)
         
-        viewModel.userInfo
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] userInfo in
-                self?.updateUI(with: userInfo)
-            })
-            .disposed(by: disposeBag)
+        // UI updates are now handled by SwiftUI view directly through @ObservedObject
+        // viewModel.userInfo
+        //     .observe(on: MainScheduler.instance)
+        //     .subscribe(onNext: { [weak self] userInfo in
+        //         self?.updateUI(with: userInfo)
+        //     })
+        //     .disposed(by: disposeBag)
     }
     
+    // These methods are no longer needed as UI updates are handled by SwiftUI view
+    // Keeping them commented for reference in case needed for future migration
+    
+    /*
     private func updateUI(with userInfo: LoginUserModel?) {
-        guard let userInfo = userInfo else { return }
-        let levelText = viewModel.getLevelText(for: userInfo.level)
-        
-        rootView.contentView.nameLabel.text = (userInfo.name.map { $0 + " 님" }) ?? "꾸물리안 님"
-        
-        let fullLevelText = "Lv. \(userInfo.level) \(levelText)"
-        rootView.contentView.levelLabel.setText(fullLevelText, style: .body05, color: .white)
-        rootView.contentView.levelLabel.setHighlightText("Lv. \(userInfo.level)", style: .body05, color: .lightGreen)
-        
-        updateProfileImage(with: userInfo.profileImageURL)
+        // UI updates now handled by SwiftUI MyPageContentSwiftUIView
     }
     
     private func updateProfileImage(with urlString: String?, localImage: UIImage? = nil) {
-        print("Attempting to update profile image with URL: \(urlString ?? "nil")")
-        if let localImage = localImage {
-            rootView.contentView.profileImageView.image = localImage
-        }
-        
-        if let urlString = urlString, let url = URL(string: urlString) {
-            rootView.contentView.profileImageView.kf.setImage(
-                with: url,
-                placeholder: localImage ?? UIImage.imgProfile,
-                options: [
-                    .transition(.fade(0.2)),
-                    .forceRefresh,
-                    .cacheOriginalImage
-                ],
-                completionHandler: { result in
-                    switch result {
-                    case .success(let value):
-                        print("Profile image loaded successfully from server. Size: \(value.image.size)")
-                    case .failure(let error):
-                        print("Failed to load profile image from server: \(error.localizedDescription)")
-                        if self.rootView.contentView.profileImageView.image == nil {
-                            self.rootView.contentView.profileImageView.image = UIImage.imgProfile
-                        }
-                    }
-                }
-            )
-        } else {
-            print("Invalid URL or nil. Using local image or default profile image.")
-            rootView.contentView.profileImageView.image = localImage ?? UIImage.imgProfile
-        }
+        // Profile image updates now handled by SwiftUI MyPageContentSwiftUIView
     }
     
     private func loadImage(from urlString: String, into imageView: UIImageView) {
-        guard let url = URL(string: urlString) else {
-            print("Invalid URL: \(urlString)")
-            return
-        }
-        
-        imageView.kf.setImage(
-            with: url,
-            placeholder: UIImage.imgProfile,
-            options: [
-                .transition(.fade(0.2)),
-                .forceRefresh,
-                .cacheOriginalImage
-            ],
-            completionHandler: { result in
-                switch result {
-                case .success(_):
-                    print("Image loaded successfully")
-                case .failure(let error):
-                    print("Failed to load image: \(error.localizedDescription)")
-                    imageView.image = UIImage.imgProfile
-                }
-            }
-        )
+        // Image loading now handled by SwiftUI MyPageContentSwiftUIView
     }
+    */
     
     private func bindRowTapGesture(for view: UIView) -> Observable<Void> {
         return view.gestureRecognizers?
@@ -218,11 +174,7 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
         editViewModel.profileImageUpdated
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] imageDataString in
-                if let imageDataString = imageDataString,
-                   let imageData = Data(base64Encoded: imageDataString),
-                   let image = UIImage(data: imageData) {
-                    self?.updateProfileImage(with: nil, localImage: image)
-                }
+                // Profile image update is now handled by SwiftUI view
                 self?.needsUserInfoRefresh = true
             })
             .disposed(by: disposeBag)

--- a/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
+++ b/KkuMulKum/Source/MyPage/ViewController/MyPageViewController.swift
@@ -14,13 +14,15 @@ import Kingfisher
 import Amplitude
 
 class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
-    private let rootView = MyPageView()
     private let viewModel = MyPageViewModel()
     private let disposeBag = DisposeBag()
     private var needsUserInfoRefresh = true
+    private var hostingController: UIHostingController<MyPageSwiftUIView>?
     
     override func loadView() {
-        view = rootView
+        super.loadView()
+        view = UIView()
+        view.backgroundColor = .green1
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -33,18 +35,13 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .green1
         
-        // Setup SwiftUI content view
-        rootView.setupSwiftUIContent(with: viewModel)
-        if let hostingController = rootView.contentHostingController {
-            addChild(hostingController)
-            hostingController.didMove(toParent: self)
-        }
+        setupSwiftUIView()
         
         Amplitude.instance().logEvent("test_event_from_app")
             print("📤 테스트 이벤트 전송 완료")
         bindViewModel()
+        setupNotificationObservers()
     }
     
     override func setupView() {
@@ -52,34 +49,52 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
         setupNavigationBarTitle(with: "마이페이지")
     }
     
+    private func setupSwiftUIView() {
+        let swiftUIView = MyPageSwiftUIView(viewModel: viewModel)
+        hostingController = UIHostingController(rootView: swiftUIView)
+        
+        guard let hostingController = hostingController else { return }
+        
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        hostingController.didMove(toParent: self)
+    }
+    
+    private func setupNotificationObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showTerms),
+            name: Notification.Name("ShowTerms"),
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showAsk),
+            name: Notification.Name("ShowAsk"),
+            object: nil
+        )
+    }
+    
+    @objc private func showTerms() {
+        pushTermsViewController()
+    }
+    
+    @objc private func showAsk() {
+        pushAskViewController()
+    }
+    
     private func bindViewModel() {
-        // Inputs
-        // Edit button is now handled by SwiftUI view directly
-        // rootView.contentView.editButton.rx.tap
-        //     .bind(to: viewModel.editButtonTapped)
-        //     .disposed(by: disposeBag)
-        
-        bindRowTapGesture(for: rootView.etcSettingView.logoutRow)
-            .bind(to: viewModel.logoutButtonTapped)
-            .disposed(by: disposeBag)
-        
-        bindRowTapGesture(for: rootView.etcSettingView.unsubscribeRow)
-            .bind(to: viewModel.unsubscribeButtonTapped)
-            .disposed(by: disposeBag)
-        
-        bindRowTapGesture(for: rootView.etcSettingView.versionInfoRow)
-            .subscribe(onNext: { print("버전정보 탭됨") })
-            .disposed(by: disposeBag)
-        
-        bindRowTapGesture(for: rootView.etcSettingView.termsOfServiceRow)
-            .subscribe(onNext: { [weak self] in
-                self?.pushTermsViewController() })
-            .disposed(by: disposeBag)
-        
-        bindRowTapGesture(for: rootView.etcSettingView.inquiryRow)
-            .subscribe(onNext: { [weak self] in
-                self?.pushAskViewController() })
-            .disposed(by: disposeBag)
+        // ViewModel bindings are now handled by SwiftUI views
         
         // Outputs
         viewModel.pushEditProfileVC
@@ -141,31 +156,6 @@ class MyPageViewController: BaseViewController, CustomActionSheetDelegate {
         //     .disposed(by: disposeBag)
     }
     
-    // These methods are no longer needed as UI updates are handled by SwiftUI view
-    // Keeping them commented for reference in case needed for future migration
-    
-    /*
-    private func updateUI(with userInfo: LoginUserModel?) {
-        // UI updates now handled by SwiftUI MyPageContentSwiftUIView
-    }
-    
-    private func updateProfileImage(with urlString: String?, localImage: UIImage? = nil) {
-        // Profile image updates now handled by SwiftUI MyPageContentSwiftUIView
-    }
-    
-    private func loadImage(from urlString: String, into imageView: UIImageView) {
-        // Image loading now handled by SwiftUI MyPageContentSwiftUIView
-    }
-    */
-    
-    private func bindRowTapGesture(for view: UIView) -> Observable<Void> {
-        return view.gestureRecognizers?
-            .compactMap { $0 as? UITapGestureRecognizer }
-            .first?
-            .rx.event
-            .map { _ in }
-        ?? Observable.empty()
-    }
     
     private func pushEditProfileViewController() {
         let editViewModel = MyPageEditViewModel(authService: AuthService())

--- a/KkuMulKum/Source/MyPage/ViewModel/MyPageViewModel.swift
+++ b/KkuMulKum/Source/MyPage/ViewModel/MyPageViewModel.swift
@@ -31,7 +31,18 @@ class MyPageViewModel: NSObject {
     
     init(userService: MyPageUserServiceProtocol = MyPageUserService()) {
         self.userService = userService
-        self.userInfo = BehaviorRelay<LoginUserModel?>(value: nil)
+        
+        // 목데이터 설정
+        let mockUserInfo = LoginUserModel(
+            userID: 1,
+            name: "테스트유저",
+            level: 3,
+            promiseCount: 15,
+            tardyCount: 2,
+            tardySum: 35,
+            profileImageURL: nil
+        )
+        self.userInfo = BehaviorRelay<LoginUserModel?>(value: mockUserInfo)
         
         pushEditProfileVC = editButtonTapped.asSignal()
         
@@ -69,6 +80,20 @@ class MyPageViewModel: NSObject {
     }
     
     func fetchUserInfo() {
+        // 서버 테스트를 위해 목데이터 사용
+        let mockUserInfo = LoginUserModel(
+            userID: 1,
+            name: "테스트유저",
+            level: 3,
+            promiseCount: 15,
+            tardyCount: 2,
+            tardySum: 35,
+            profileImageURL: nil
+        )
+        userInfo.accept(mockUserInfo)
+        
+        // 실제 서버 호출은 주석 처리
+        /*
         Task {
             do {
                 let info = try await userService.getUserInfo()
@@ -77,6 +102,7 @@ class MyPageViewModel: NSObject {
                 print("Failed to fetch user info: \(error)")
             }
         }
+        */
     }
     
     func logout() {


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #417 

## 📄 작업 내용
- UIkit 으로 구현한 Mypage 부분을 SwiftUI로 마이그레이션
- UIkit 기반의 네비게이션 뷰를 통해 뷰만 SwiftUI로 전환


## 💻 주요 코드 설명

RxSwift와 SwiftUI의 데이터 바인딩 통합

문제점: RxSwift BehaviorRelay vs SwiftUI @ObservedObject

기존 UIKit + RxSwift 코드

```swift
// ViewModel (RxSwift)
class MyPageViewModel {
let userInfo: BehaviorRelay<LoginUserModel?> = BehaviorRelay(value: nil)
let editButtonTapped = PublishRelay<Void>()
}

// ViewController
viewModel.userInfo
.observe(on: MainScheduler.instance)
.subscribe(onNext: { [weak self] userInfo in
self?.updateUI(with: userInfo)
})
.disposed(by: disposeBag)

```

### 문제 상황

SwiftUI의 @ObservedObject는 Combine의 ObservableObject 프로토콜을 준수해야
하는데, RxSwift의 BehaviorRelay는 준수안함 (당연함)

```swift
// ❌ 컴파일 에러 발생
struct MyPageContentSwiftUIView: View {
@ObservedObject var viewModel: MyPageViewModel  // Error: MyPageViewModel은 ObservableObject가 아님
}
```

해결책: Wrapper 패턴으로 브리징

[[ObservableObject](https://developer.apple.com/documentation/combine/observableobject)](https://developer.apple.com/documentation/combine/observableobject) 를 써서 Wrapper 클래스로 해결핑

```swift
// Wrapper 클래스로 RxSwift → Combine 브리징
class MyPageViewModelWrapper: ObservableObject {
@Published var userInfo: LoginUserModel?  // Combine의 @Published
let viewModel: MyPageViewModel            // 기존 RxSwift ViewModel
private let disposeBag = DisposeBag()

  init(viewModel: MyPageViewModel) {
      self.viewModel = viewModel

      // RxSwift Observable을 Combine @Published로 변환
      viewModel.userInfo
          .subscribe(onNext: { [weak self] info in
              DispatchQueue.main.async {
                  self?.userInfo = info  // @Published 프로퍼티 업데이트
              }
          })
          .disposed(by: disposeBag)
  }

}

// SwiftUI View에서 사용
struct MyPageContentSwiftUIView: View {
@StateObject private var viewModelWrapper: MyPageViewModelWrapper

  init(viewModel: MyPageViewModel) {
      _viewModelWrapper = StateObject(wrappedValue:
      MyPageViewModelWrapper(viewModel: viewModel))
}

  var body: some View {
      Text(viewModelWrapper.userInfo?.name ?? "Unknown")
          .onChange(of: viewModelWrapper.userInfo) { newValue in
              // 변경 감지
          }
  }

}
```

## UIHostingController 통합

문제점: 네비게이션 구조 유지

https://developer.apple.com/documentation/swiftui/uihostingcontroller

### 1. 전체 교체 (했다가 실패함ㅠ)

```swift
// ❌ 문제가 있었던 접근
class MyPageViewController: UIHostingController<MyPageSwiftUIView> {
				init() {
					super.init(rootView: MyPageSwiftUIView())
			}
}
```

문제는 BaseViewController의 기능 상실, 네비게이션 바 커스터마이징 어려워지게 되더라구요

해서 안되니까 Child View Controller 채택

```swift
class MyPageViewController: BaseViewController {
private var hostingController: UIHostingController<MyPageSwiftUIView>?

  private func setupSwiftUIView() {
      let swiftUIView = MyPageSwiftUIView(viewModel: viewModel)
      hostingController = UIHostingController(rootView: swiftUIView)

      guard let hostingController = hostingController else { return }

      // Child View Controller로 추가 (Apple 권장 방식)
      addChild(hostingController)
      view.addSubview(hostingController.view)

      // Auto Layout 설정 -> 이건 전체 뷰 바꾸기 이전 상황이라 일단 기본으로..
      hostingController.view.translatesAutoresizingMaskIntoConstraints = false
NSLayoutConstraint.activate([
...
])
      hostingController.didMove(toParent: self)  //부모-자식 관계 지정
```

## 문제점: fillEqually Distribution 구현

https://developer.apple.com/documentation/swiftui/geometryreader

기존코드

```swift
class MyPageEtcSettingView: BaseView {
		let stackView = UIStackView(axis: .vertical).then {
				$0.spacing = 12
				$0.distribution = .fillEqually  
}
...

  override func setupAutoLayout() {
      stackView.snp.makeConstraints {
          $0.edges.equalToSuperview().inset(22)
      }
...
  
  
```

GeometryReader로 바로 정상

```swift

struct MyPageEtcSettingSwiftUIView: View {
		var body: some View {
				GeometryReader { geometry in
					VStack(spacing: 12) {
let itemCount = 5
let totalSpacing = 12 * (itemCount - 1)  // 48
let padding = 44  // 상하 패딩 22 * 2
let itemHeight = (geometry.size.height - CGFloat(padding) -
CGFloat(totalSpacing)) / CGFloat(itemCount)

              SettingRow(title: "버전정보", subtitle: "1.0.2")
                  .frame(height: itemHeight)  // fillEqually 효과

              SettingRow(title: "이용약관")
                  .frame(height: itemHeight)

              SettingRow(title: "문의하기")
                  .frame(height: itemHeight)

              SettingRow(title: "로그아웃")
                  .frame(height: itemHeight)

              SettingRow(title: "탈퇴하기")
                  .frame(height: itemHeight)
          }
          .padding(22)
      }
  }

}
```

## 네비게이션 로직은 UIkit이 뷰만 SwiftUI에서

SwiftUI에서 UIKit ViewController Push를 유지해야 하는 상황 [[참고](https://developer.apple.com/documentation/swiftui/uiviewcontrollerrepresentable)](https://developer.apple.com/documentation/swiftui/uiviewcontrollerrepresentable)

- 네비게이션 로직: UIKit (UINavigationController, push/pop 등)
    - 개별 화면(View): SwiftUI
    - 화면 비율 유틸리티: UIKit의 Screen 클래스를 SwiftUI View에서 재사용
    
    구체적인 구조
    
    ```swift
    // UIKit - ViewController에서 네비게이션 처리
    class ProfileViewController: UIViewController {
    
    	override func viewDidLoad() {
    	super.viewDidLoad()
    
    // SwiftUI View를 UIHostingController로 감싸서 사용
    let swiftUIView = ProfileView(
         profileImage: userImage,
         name: userName
     )
    
    let hostingController = UIHostingController(rootView: swiftUIView)
    
    // UIKit 네비게이션으로 push
     navigationController?.pushViewController(hostingController, animated: true)
    }
    
    // SwiftUI - View만 담당
    struct ProfileView: View {
    let profileImage: UIImage
    let name: String
    
    var body: some View {
        VStack {
            Image(uiImage: profileImage)
                .frame(
                    width: Screen.height(82),   // UIKit의 Screen 유틸리티 사용
    								height: Screen.height(82)
    )
            Text(name)
                .padding(.top, Screen.height(12))
    	    }
    		}
    
    	}
    ```
    

## Equatable 프로토콜 추가

문제점: [[onChange](https://developer.apple.com/documentation/swiftui/view/onchange(of:perform:))](https://developer.apple.com/documentation/swiftui/view/onchange(of:perform:)) 모디파이어 사용 시 필요

```swift
// ❌ 컴파일 에러
.onChange(of: viewModelWrapper.userInfo) { newValue in
// Error: LoginUserModel이 Equatable이 아님
}

해결책: Model에 Equatable 추가

// Before
struct LoginUserModel: ResponseModelType {
let userID: Int
let name: String?
}

// After
struct LoginUserModel: ResponseModelType, Equatable {  // Equatable 추가
let userID: Int
let name: String?
}
```

## 👀 기타 더 이야기해볼 점
마이그레이션은 하나씩 천천히 해야겟어요 간단한뷰라 쉬울줄알앗는데 개헷갈림;;